### PR TITLE
ci: Automate version bump to v2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "qp-poseidon-core"
-version = "1.5.0"
+version = "2.0.0"
 dependencies = [
  "criterion",
  "dudect-bencher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["core"]
 
 [workspace.package]
-version = "1.5.0"
+version = "2.0.0"
 authors = ["Quantus Network Developers <hello@quantus.com>"]
 homepage = "https://quantus.com"
 repository = "https://github.com/Quantus-Network/qp-poseidon"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version-only change with no logic, crypto, or dependency updates beyond the lockfile version field.
> 
> **Overview**
> Bumps the workspace crate version from **1.5.0** to **2.0.0**, which flows to `qp-poseidon-core` via `version.workspace = true` and is reflected in **Cargo.lock**. There are no source or API changes in this diff—only release metadata for a major version cut.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1a7e9a34092bd760c3f2bd8355450bcf9e8be74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->