### PR TITLE
ci: Automate version bump to v2.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "qp-poseidon-core"
-version = "2.0.0"
+version = "2.0.2"
 dependencies = [
  "criterion",
  "dudect-bencher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["core"]
 
 [workspace.package]
-version = "2.0.0"
+version = "2.0.2"
 authors = ["Quantus Network Developers <hello@quantus.com>"]
 homepage = "https://quantus.com"
 repository = "https://github.com/Quantus-Network/qp-poseidon"


### PR DESCRIPTION
Automated version bump for release v2.0.2.

https://github.com/Quantus-Network/qp-poseidon/actions/runs/26563624050

Triggered by workflow run: custom

Type: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only version and lockfile updates with no application or cryptographic logic changes.
> 
> **Overview**
> Bumps the workspace and crate versions from **2.0.0** to **2.0.2** as part of an automated release workflow.
> 
> `Cargo.toml` updates `[workspace.package].version`, and `Cargo.lock` reflects the new version for `qp-poseidon-core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e031d42cc9a7992e814643aa8728ed74e83b983. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->