### PR TITLE
ci: Automate version bump to v2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "qp-poseidon-core"
-version = "2.0.2"
+version = "2.1.0"
 dependencies = [
  "criterion",
  "dudect-bencher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qp-poseidon-core"
-version = "2.0.2"
+version = "2.1.0"
 authors = ["Quantus Network Developers <hello@quantus.com>"]
 homepage = "https://quantus.com"
 repository = "https://github.com/Quantus-Network/qp-poseidon"


### PR DESCRIPTION
Automated version bump for release v2.1.0.

https://github.com/Quantus-Network/qp-poseidon/actions/runs/26933857531

Triggered by workflow run: minor

Type: 