### PR TITLE
V12 again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 - **Breaking**: `bytes_to_digest`, `bytes_to_felts_compact`, and `rehash_to_bytes` now return `Result`, rejecting 8-byte limbs that encode values `>= P` (non-canonical field encodings that alias with canonical elements and enabled hash collisions)
+- **Breaking**: `u128_to_quantized_felt` replaced by `try_u128_to_quantized_felt`, which returns `Result` instead of panicking on amounts whose quantized value exceeds 32 bits
 - `hash_bytes` and `hash_squeeze_twice` now absorb input incrementally instead of materializing the serialized preimage on the heap (fixes unbounded allocation on attacker-sized inputs)
 - Added `bytes_to_felts_iter` / `bytes_to_u64s_iter` for allocation-free streaming of the injective encoding
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 📈 Changelog
 
+### Unreleased
+- **Breaking**: `bytes_to_digest`, `bytes_to_felts_compact`, and `rehash_to_bytes` now return `Result`, rejecting 8-byte limbs that encode values `>= P` (non-canonical field encodings that alias with canonical elements and enabled hash collisions)
+- `hash_bytes` and `hash_squeeze_twice` now absorb input incrementally instead of materializing the serialized preimage on the heap (fixes unbounded allocation on attacker-sized inputs)
+- Added `bytes_to_felts_iter` / `bytes_to_u64s_iter` for allocation-free streaming of the injective encoding
+
 ### Version 0.9.1
 - Restructured as workspace with separate core and substrate crates
 - Added no-std support for core crate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 - **Breaking**: `bytes_to_digest`, `bytes_to_felts_compact`, and `rehash_to_bytes` now return `Result`, rejecting 8-byte limbs that encode values `>= P` (non-canonical field encodings that alias with canonical elements and enabled hash collisions)
+- Added `bytes_to_digest_lossy`, an explicitly-labelled infallible variant preserving the old reduce-mod-P behavior for callers that intentionally want a lossy commitment over non-field data (e.g. binding Blake2 roots into a Poseidon preimage)
 - **Breaking**: `u128_to_quantized_felt` replaced by `try_u128_to_quantized_felt`, which returns `Result` instead of panicking on amounts whose quantized value exceeds 32 bits
 - **Breaking**: `u64s_to_digest` now returns `Result`, rejecting limbs that exceed 32 bits instead of silently truncating them (distinct limb arrays could previously alias to the same digest)
 - `hash_bytes` and `hash_squeeze_twice` now absorb input incrementally instead of materializing the serialized preimage on the heap (fixes unbounded allocation on attacker-sized inputs)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **Breaking**: `u128_to_quantized_felt` replaced by `try_u128_to_quantized_felt`, which returns `Result` instead of panicking on amounts whose quantized value exceeds 32 bits
 - `hash_bytes` and `hash_squeeze_twice` now absorb input incrementally instead of materializing the serialized preimage on the heap (fixes unbounded allocation on attacker-sized inputs)
 - Added `bytes_to_felts_iter` / `bytes_to_u64s_iter` for allocation-free streaming of the injective encoding
+- Docs: narrowed the constant-time claim — Goldilocks add/sub/reduce contain rare value-dependent correction branches, so dudect results are empirical evidence rather than a branch-free guarantee
 
 ### Version 0.9.1
 - Restructured as workspace with separate core and substrate crates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 - **Breaking**: `bytes_to_digest`, `bytes_to_felts_compact`, and `rehash_to_bytes` now return `Result`, rejecting 8-byte limbs that encode values `>= P` (non-canonical field encodings that alias with canonical elements and enabled hash collisions)
 - **Breaking**: `u128_to_quantized_felt` replaced by `try_u128_to_quantized_felt`, which returns `Result` instead of panicking on amounts whose quantized value exceeds 32 bits
+- **Breaking**: `u64s_to_digest` now returns `Result`, rejecting limbs that exceed 32 bits instead of silently truncating them (distinct limb arrays could previously alias to the same digest)
 - `hash_bytes` and `hash_squeeze_twice` now absorb input incrementally instead of materializing the serialized preimage on the heap (fixes unbounded allocation on attacker-sized inputs)
 - Added `bytes_to_felts_iter` / `bytes_to_u64s_iter` for allocation-free streaming of the injective encoding
 - Docs: narrowed the constant-time claim — Goldilocks add/sub/reduce contain rare value-dependent correction branches, so dudect results are empirical evidence rather than a branch-free guarantee

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `hash_bytes` and `hash_squeeze_twice` now absorb input incrementally instead of materializing the serialized preimage on the heap (fixes unbounded allocation on attacker-sized inputs)
 - Added `bytes_to_felts_iter` / `bytes_to_u64s_iter` for allocation-free streaming of the injective encoding
 - Docs: narrowed the constant-time claim — Goldilocks add/sub/reduce contain rare value-dependent correction branches, so dudect results are empirical evidence rather than a branch-free guarantee
+- `ct_bench` timed closures now route inputs and outputs through `black_box`, preventing the optimizer from eliding the measured hashing work and silently weakening the timing regression gate
 
 ### Version 0.9.1
 - Restructured as workspace with separate core and substrate crates

--- a/CONSTANT_TIME_TESTING.md
+++ b/CONSTANT_TIME_TESTING.md
@@ -2,6 +2,16 @@
 
 This project uses [dudect-bencher](https://github.com/rozbb/dudect-bencher) to test whether the Poseidon2 hash functions execute in constant time, preventing timing side-channel attacks.
 
+## Scope of the guarantee
+
+These tests provide *empirical* evidence of constant-time behavior, not a proof. The
+underlying `Goldilocks` field arithmetic contains rare carry/borrow correction branches
+(in `add`, `sub`, and `reduce128`, deliberately shaped by `branch_hint`) that depend on
+operand values. They fire only when intermediate values land near or above the modulus,
+which is why dudect measurements show no stable timing distinguisher — but strictly
+speaking the code is not branch-free. Treat passing t-scores as "no measurable leakage
+in this environment", not as a hard constant-time guarantee.
+
 ## Quick Start
 
 Run all constant-time tests:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ let chained = rehash_to_bytes(&hash).unwrap();
 - **Injective encoding**: `hash_bytes` is collision-resistant for any input length
 - **Compact encoding**: Only use `bytes_to_felts_compact` for fixed-size inputs (e.g., in ZK circuits where input size is constrained)
 - **Canonical decoding**: `bytes_to_digest`, `rehash_to_bytes`, and `bytes_to_felts_compact` reject 8-byte limbs that encode values `>= P`, preventing byte-distinct inputs from aliasing to the same field elements
-- **Constant-time**: Core hashing has no input-dependent branches; timing tests pass with dudect t-scores < 5
+- **Timing behavior**: Empirical dudect timing tests show no measurable input-dependent timing (t-scores < 5); see `CONSTANT_TIME_TESTING.md`. Note that the field arithmetic is not strictly branch-free: `Goldilocks` add/sub/reduce take rare carry/borrow correction branches (inherited from the standard optimized Goldilocks implementation) that fire only for values near the modulus. Do not rely on this crate for hard constant-time guarantees on secret inputs.
 - **No padding vulnerabilities**: Removed legacy padded hashing functions that had audit issues
 
 ## License

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ let chained = rehash_to_bytes(&hash).unwrap();
 | `bytes_to_felts(&[u8])` | Injective encoding: 4 bytes/felt + terminator |
 | `bytes_to_felts_compact(&[u8])` | Compact encoding: 8 bytes/felt (fixed-size inputs only; errors on non-canonical limbs) |
 | `bytes_to_digest(&[u8; 32])` | Decode 32 bytes as 4 field elements (errors on non-canonical limbs) |
+| `bytes_to_digest_lossy(&[u8; 32])` | Infallible decode that reduces non-canonical limbs mod P (NOT injective; lossy commitments only) |
 | `digest_to_bytes(&[Goldilocks; 4])` | Encode 4 field elements as 32 bytes |
 | `string_to_felts(&str)` | Encode string as field elements |
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ let hash = hash_to_bytes(&felts);
 // Double hash for address derivation
 let address = hash_twice(&felts);
 
-// Re-hash a 32-byte digest
-let chained = rehash_to_bytes(&hash);
+// Re-hash a 32-byte digest (errors on non-canonical digest bytes)
+let chained = rehash_to_bytes(&hash).unwrap();
 ```
 
 ## Public API
@@ -44,7 +44,7 @@ let chained = rehash_to_bytes(&hash);
 | `hash_to_bytes(&[Goldilocks])` | Hash field elements, return 32 bytes |
 | `hash_to_felts(&[Goldilocks])` | Hash field elements, return 4 field elements |
 | `hash_twice(&[Goldilocks])` | Double hash: `hash(hash(input))` for wormhole addresses |
-| `rehash_to_bytes(&[u8; 32])` | Re-hash a 32-byte digest |
+| `rehash_to_bytes(&[u8; 32])` | Re-hash a 32-byte digest (errors on non-canonical input) |
 | `hash_squeeze_twice(&[u8])` | 64-byte output (two squeezes) for mining PoW |
 
 ### Serialization (`serialization` module)
@@ -52,8 +52,8 @@ let chained = rehash_to_bytes(&hash);
 | Function | Description |
 |----------|-------------|
 | `bytes_to_felts(&[u8])` | Injective encoding: 4 bytes/felt + terminator |
-| `bytes_to_felts_compact(&[u8])` | Compact encoding: 8 bytes/felt (fixed-size inputs only) |
-| `bytes_to_digest(&[u8; 32])` | Decode 32 bytes as 4 field elements |
+| `bytes_to_felts_compact(&[u8])` | Compact encoding: 8 bytes/felt (fixed-size inputs only; errors on non-canonical limbs) |
+| `bytes_to_digest(&[u8; 32])` | Decode 32 bytes as 4 field elements (errors on non-canonical limbs) |
 | `digest_to_bytes(&[Goldilocks; 4])` | Encode 4 field elements as 32 bytes |
 | `string_to_felts(&str)` | Encode string as field elements |
 
@@ -61,6 +61,7 @@ let chained = rehash_to_bytes(&hash);
 
 - **Injective encoding**: `hash_bytes` is collision-resistant for any input length
 - **Compact encoding**: Only use `bytes_to_felts_compact` for fixed-size inputs (e.g., in ZK circuits where input size is constrained)
+- **Canonical decoding**: `bytes_to_digest`, `rehash_to_bytes`, and `bytes_to_felts_compact` reject 8-byte limbs that encode values `>= P`, preventing byte-distinct inputs from aliasing to the same field elements
 - **Constant-time**: Core hashing has no input-dependent branches; timing tests pass with dudect t-scores < 5
 - **No padding vulnerabilities**: Removed legacy padded hashing functions that had audit issues
 

--- a/clippy.sh
+++ b/clippy.sh
@@ -2,4 +2,6 @@
 # Run the same clippy command as CI (see .github/workflows/ci.yml)
 set -euo pipefail
 
+cargo +nightly fmt
+taplo format
 cargo clippy --workspace --all-targets --all-features --locked -- -D warnings

--- a/examples/ct_bench.rs
+++ b/examples/ct_bench.rs
@@ -556,8 +556,9 @@ fn test_integrated_operations_ct(runner: &mut CtRunner, rng: &mut BenchRng) {
 		runner.run_one(class, || {
 			// Test a sequence of operations that might be used together
 			let hash = hash_bytes(&input);
-			// Chain with rehash (tests bytes -> felts -> hash path)
-			let _rehash = rehash_to_bytes(&hash);
+			// Chain with rehash (tests bytes -> felts -> hash path).
+			// Library-produced digests are always canonical, so this cannot fail.
+			let _rehash = rehash_to_bytes(&hash).expect("canonical digest");
 			let _squeeze = hash_squeeze_twice(&input);
 		});
 	}

--- a/examples/ct_bench.rs
+++ b/examples/ct_bench.rs
@@ -9,6 +9,8 @@
 //!
 //! This ensures the two classes are distinguishable before timing analysis begins.
 
+use std::hint::black_box;
+
 use dudect_bencher::{
 	rand::{Rng, RngCore},
 	BenchRng, Class, CtRunner,
@@ -99,7 +101,7 @@ fn test_hash_bytes_small_ct(runner: &mut CtRunner, rng: &mut BenchRng) {
 		disrupt_cache(rng);
 
 		runner.run_one(class, || {
-			let _result = hash_bytes(&input);
+			black_box(hash_bytes(black_box(&input)));
 		});
 	}
 }
@@ -120,7 +122,7 @@ fn test_hash_bytes_medium_ct(runner: &mut CtRunner, rng: &mut BenchRng) {
 		disrupt_cache(rng);
 
 		runner.run_one(class, || {
-			let _result = hash_bytes(&input);
+			black_box(hash_bytes(black_box(&input)));
 		});
 	}
 }
@@ -141,7 +143,7 @@ fn test_hash_bytes_large_ct(runner: &mut CtRunner, rng: &mut BenchRng) {
 		disrupt_cache(rng);
 
 		runner.run_one(class, || {
-			let _result = hash_bytes(&input);
+			black_box(hash_bytes(black_box(&input)));
 		});
 	}
 }
@@ -162,7 +164,7 @@ fn test_hash_bytes_xlarge_ct(runner: &mut CtRunner, rng: &mut BenchRng) {
 		disrupt_cache(rng);
 
 		runner.run_one(class, || {
-			let _result = hash_bytes(&input);
+			black_box(hash_bytes(black_box(&input)));
 		});
 	}
 }
@@ -183,7 +185,7 @@ fn test_hash_variable_length_bytes_small_ct(runner: &mut CtRunner, rng: &mut Ben
 		disrupt_cache(rng);
 
 		runner.run_one(class, || {
-			let _result = hash_bytes(&input);
+			black_box(hash_bytes(black_box(&input)));
 		});
 	}
 }
@@ -204,7 +206,7 @@ fn test_hash_variable_length_bytes_medium_ct(runner: &mut CtRunner, rng: &mut Be
 		disrupt_cache(rng);
 
 		runner.run_one(class, || {
-			let _result = hash_bytes(&input);
+			black_box(hash_bytes(black_box(&input)));
 		});
 	}
 }
@@ -225,7 +227,7 @@ fn test_hash_variable_length_bytes_large_ct(runner: &mut CtRunner, rng: &mut Ben
 		disrupt_cache(rng);
 
 		runner.run_one(class, || {
-			let _result = hash_bytes(&input);
+			black_box(hash_bytes(black_box(&input)));
 		});
 	}
 }
@@ -255,8 +257,9 @@ fn test_poseidon2_permutation_ct(runner: &mut CtRunner, rng: &mut BenchRng) {
 		disrupt_cache(rng);
 
 		runner.run_one(class, || {
-			let mut state_copy = state;
+			let mut state_copy = black_box(state);
 			poseidon.permute_mut(&mut state_copy);
+			black_box(state_copy);
 		});
 	}
 }
@@ -277,7 +280,7 @@ fn test_hash_squeeze_twice_small_ct(runner: &mut CtRunner, rng: &mut BenchRng) {
 		disrupt_cache(rng);
 
 		runner.run_one(class, || {
-			let _result = hash_squeeze_twice(&input);
+			black_box(hash_squeeze_twice(black_box(&input)));
 		});
 	}
 }
@@ -298,7 +301,7 @@ fn test_hash_squeeze_twice_medium_ct(runner: &mut CtRunner, rng: &mut BenchRng) 
 		disrupt_cache(rng);
 
 		runner.run_one(class, || {
-			let _result = hash_squeeze_twice(&input);
+			black_box(hash_squeeze_twice(black_box(&input)));
 		});
 	}
 }
@@ -319,7 +322,7 @@ fn test_hash_squeeze_twice_large_ct(runner: &mut CtRunner, rng: &mut BenchRng) {
 		disrupt_cache(rng);
 
 		runner.run_one(class, || {
-			let _result = hash_squeeze_twice(&input);
+			black_box(hash_squeeze_twice(black_box(&input)));
 		});
 	}
 }
@@ -340,7 +343,7 @@ fn test_field_absorption_small_ct(runner: &mut CtRunner, rng: &mut BenchRng) {
 		disrupt_cache(rng);
 
 		runner.run_one(class, || {
-			let _felts: Vec<Goldilocks> = bytes_to_felts(&input);
+			black_box::<Vec<Goldilocks>>(bytes_to_felts(black_box(&input)));
 		});
 	}
 }
@@ -361,7 +364,7 @@ fn test_field_absorption_medium_ct(runner: &mut CtRunner, rng: &mut BenchRng) {
 		disrupt_cache(rng);
 
 		runner.run_one(class, || {
-			let _felts: Vec<Goldilocks> = bytes_to_felts(&input);
+			black_box::<Vec<Goldilocks>>(bytes_to_felts(black_box(&input)));
 		});
 	}
 }
@@ -382,7 +385,7 @@ fn test_field_absorption_large_ct(runner: &mut CtRunner, rng: &mut BenchRng) {
 		disrupt_cache(rng);
 
 		runner.run_one(class, || {
-			let _felts: Vec<Goldilocks> = bytes_to_felts(&input);
+			black_box::<Vec<Goldilocks>>(bytes_to_felts(black_box(&input)));
 		});
 	}
 }
@@ -403,7 +406,7 @@ fn test_double_hash_small_ct(runner: &mut CtRunner, rng: &mut BenchRng) {
 		disrupt_cache(rng);
 
 		runner.run_one(class, || {
-			let _result = hash_twice(&felts);
+			black_box(hash_twice(black_box(&felts)));
 		});
 	}
 }
@@ -424,7 +427,7 @@ fn test_double_hash_medium_ct(runner: &mut CtRunner, rng: &mut BenchRng) {
 		disrupt_cache(rng);
 
 		runner.run_one(class, || {
-			let _result = hash_twice(&felts);
+			black_box(hash_twice(black_box(&felts)));
 		});
 	}
 }
@@ -445,7 +448,7 @@ fn test_hash_variable_length_felts_small_ct(runner: &mut CtRunner, rng: &mut Ben
 		disrupt_cache(rng);
 
 		runner.run_one(class, || {
-			let _result = hash_to_bytes(&felts);
+			black_box(hash_to_bytes(black_box(&felts)));
 		});
 	}
 }
@@ -466,7 +469,7 @@ fn test_hash_variable_length_felts_medium_ct(runner: &mut CtRunner, rng: &mut Be
 		disrupt_cache(rng);
 
 		runner.run_one(class, || {
-			let _result = hash_to_bytes(&felts);
+			black_box(hash_to_bytes(black_box(&felts)));
 		});
 	}
 }
@@ -487,7 +490,7 @@ fn test_hash_variable_length_felts_large_ct(runner: &mut CtRunner, rng: &mut Ben
 		disrupt_cache(rng);
 
 		runner.run_one(class, || {
-			let _result = hash_to_bytes(&felts);
+			black_box(hash_to_bytes(black_box(&felts)));
 		});
 	}
 }
@@ -508,7 +511,7 @@ fn test_double_hash_large_ct(runner: &mut CtRunner, rng: &mut BenchRng) {
 		disrupt_cache(rng);
 
 		runner.run_one(class, || {
-			let _result = hash_twice(&felts);
+			black_box(hash_twice(black_box(&felts)));
 		});
 	}
 }
@@ -533,7 +536,7 @@ fn test_single_byte_edge_cases_ct(runner: &mut CtRunner, rng: &mut BenchRng) {
 		disrupt_cache(rng);
 
 		runner.run_one(class, || {
-			let _result = hash_bytes(&input);
+			black_box(hash_bytes(black_box(&input)));
 		});
 	}
 }
@@ -555,11 +558,11 @@ fn test_integrated_operations_ct(runner: &mut CtRunner, rng: &mut BenchRng) {
 
 		runner.run_one(class, || {
 			// Test a sequence of operations that might be used together
-			let hash = hash_bytes(&input);
+			let hash = hash_bytes(black_box(&input));
 			// Chain with rehash (tests bytes -> felts -> hash path).
 			// Library-produced digests are always canonical, so this cannot fail.
-			let _rehash = rehash_to_bytes(&hash).expect("canonical digest");
-			let _squeeze = hash_squeeze_twice(&input);
+			black_box(rehash_to_bytes(&hash).expect("canonical digest"));
+			black_box(hash_squeeze_twice(black_box(&input)));
 		});
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,6 @@ pub mod serialization;
 pub use goldilocks::Goldilocks;
 pub use poseidon2::{Poseidon2, POSEIDON2_OUTPUT, SPONGE_CAPACITY, SPONGE_RATE, SPONGE_WIDTH};
 
-use crate::serialization::bytes_to_felts;
-
 // Internal state for Poseidon2 hashing
 struct Poseidon2State {
 	poseidon2: Poseidon2,
@@ -54,9 +52,12 @@ impl Poseidon2State {
 		}
 	}
 
+	/// Absorb bytes using the injective 4-bytes/felt encoding, streaming felts from
+	/// [`serialization::bytes_to_felts_iter`] directly into the sponge.
 	fn append_bytes(&mut self, bytes: &[u8]) {
-		let felts = bytes_to_felts(bytes);
-		self.append(&felts);
+		for felt in serialization::bytes_to_felts_iter(bytes) {
+			self.push_to_buf(felt);
+		}
 	}
 
 	fn finalize_state(mut self) -> [Goldilocks; SPONGE_WIDTH] {
@@ -163,7 +164,7 @@ pub fn hash_squeeze_twice(x: &[u8]) -> [u8; 64] {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::alloc::string::ToString;
+	use crate::{alloc::string::ToString, serialization::bytes_to_felts};
 	use alloc::{format, vec, vec::Vec};
 
 	#[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -568,9 +568,6 @@ mod tests {
 	#[test]
 	fn test_rehash_to_bytes_rejects_non_canonical_digest() {
 		let non_canonical = [0xFFu8; 32];
-		assert_eq!(
-			rehash_to_bytes(&non_canonical),
-			Err("Digest limb exceeds Goldilocks modulus")
-		);
+		assert_eq!(rehash_to_bytes(&non_canonical), Err("Digest limb exceeds Goldilocks modulus"));
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,9 +146,13 @@ pub fn hash_twice(x: &[Goldilocks]) -> [u8; 32] {
 ///
 /// Decodes the input bytes as 4 field elements (8 bytes/felt), hashes them,
 /// and returns the result as 32 bytes. Use this when chaining hash outputs.
-pub fn rehash_to_bytes(x: &[u8; 32]) -> [u8; 32] {
-	let felts: [Goldilocks; POSEIDON2_OUTPUT] = serialization::bytes_to_digest(x);
-	hash_to_bytes(&felts)
+///
+/// Returns an error if the input is not a canonical digest encoding (any 8-byte
+/// limb `>= P` would alias with a canonical field element and enable collisions).
+/// Digests produced by this library's hash functions are always canonical.
+pub fn rehash_to_bytes(x: &[u8; 32]) -> Result<[u8; 32], &'static str> {
+	let felts: [Goldilocks; POSEIDON2_OUTPUT] = serialization::bytes_to_digest(x)?;
+	Ok(hash_to_bytes(&felts))
 }
 
 /// Hash with 512-bit output by squeezing the sponge twice.
@@ -315,8 +319,9 @@ mod tests {
 
 		assert_eq!(serialization::digest_to_bytes(&hash_felts_result), hash_bytes_result);
 
-		let roundtrip =
-			serialization::digest_to_bytes(&serialization::bytes_to_digest(&hash_bytes_result));
+		let roundtrip = serialization::digest_to_bytes(
+			&serialization::bytes_to_digest(&hash_bytes_result).unwrap(),
+		);
 		assert_eq!(roundtrip, hash_bytes_result);
 	}
 
@@ -347,7 +352,7 @@ mod tests {
 
 		// Method 2: hash_to_bytes then rehash_to_bytes (used in chain for wormhole)
 		let first_hash = hash_to_bytes(&input);
-		let rehashed = rehash_to_bytes(&first_hash);
+		let rehashed = rehash_to_bytes(&first_hash).unwrap();
 
 		assert_eq!(
 			double_hash, rehashed,
@@ -358,7 +363,7 @@ mod tests {
 		for test_input in [b"secret1".as_slice(), b"another_secret", b""] {
 			let felts = bytes_to_felts(test_input);
 			let via_hash_twice = hash_twice(&felts);
-			let via_rehash = rehash_to_bytes(&hash_to_bytes(&felts));
+			let via_rehash = rehash_to_bytes(&hash_to_bytes(&felts)).unwrap();
 			assert_eq!(via_hash_twice, via_rehash);
 		}
 	}
@@ -548,22 +553,24 @@ mod tests {
 		// All zeros
 		let zeros = [0u8; 32];
 		assert_eq!(
-			hex::encode(rehash_to_bytes(&zeros)),
+			hex::encode(rehash_to_bytes(&zeros).unwrap()),
 			"ca0aefbd2e87c9ecc4716b7db8e83937a45dfb06ea10e1d62a4c2f2784002290"
 		);
 
-		// Sequential bytes 0..32
+		// Sequential bytes 0..32 (each 8-byte limb is canonical)
 		let seq: [u8; 32] = core::array::from_fn(|i| i as u8);
 		assert_eq!(
-			hex::encode(rehash_to_bytes(&seq)),
+			hex::encode(rehash_to_bytes(&seq).unwrap()),
 			"c0877470eb2fbfc7cc6f22ab70955509de54f3b89856d6a58399a7b7d9d26252"
 		);
+	}
 
-		// All 0xFF
-		let ones = [0xFFu8; 32];
+	#[test]
+	fn test_rehash_to_bytes_rejects_non_canonical_digest() {
+		let non_canonical = [0xFFu8; 32];
 		assert_eq!(
-			hex::encode(rehash_to_bytes(&ones)),
-			"242fcadf76ea91d398421eb1136b1dbf9f79bdadd79662a21689a0823cf46746"
+			rehash_to_bytes(&non_canonical),
+			Err("Digest limb exceeds Goldilocks modulus")
 		);
 	}
 }

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -203,7 +203,17 @@ impl<'a> Iterator for BytesToU64sIter<'a> {
 		last[remainder.len()] = 1u8;
 		Some(u32::from_le_bytes(last) as u64)
 	}
+
+	fn size_hint(&self) -> (usize, Option<usize>) {
+		// Remaining full 4-byte chunks, plus the terminator word (which also
+		// carries any final partial chunk) if not yet emitted.
+		let remaining = (self.input.len() - self.pos) / BYTES_PER_FELT
+			+ usize::from(!self.emitted_terminator);
+		(remaining, Some(remaining))
+	}
 }
+
+impl ExactSizeIterator for BytesToU64sIter<'_> {}
 
 /// Lazily encode bytes into u64 limbs (4 bytes per element + terminator).
 pub fn bytes_to_u64s_iter(input: &[u8]) -> BytesToU64sIter<'_> {
@@ -326,6 +336,26 @@ pub fn bytes_to_digest(
 	Ok(out)
 }
 
+/// Convert 32 bytes to a digest (4 field elements), **reducing non-canonical limbs**.
+///
+/// Each 8-byte chunk is interpreted as a `u64` and mapped into the field, where
+/// values `>= P` reduce to `value - P`. This map is **NOT injective**: byte-distinct
+/// inputs can decode to identical field elements and therefore hash identically
+/// downstream. Unlike [`bytes_to_digest`], it never fails.
+///
+/// Use this only where a lossy commitment is explicitly acceptable — e.g. binding
+/// non-field data (such as Blake2 hashes) into a Poseidon preimage where rare
+/// aliasing (~2^-32 per limb) is tolerable and the conversion must be infallible.
+/// For anything relying on uniqueness of the input bytes (deduplication,
+/// authorization, replay prevention), use [`bytes_to_digest`] instead.
+pub fn bytes_to_digest_lossy(input: &BytesDigest) -> [Goldilocks; POSEIDON2_OUTPUT] {
+	core::array::from_fn(|i| {
+		let start = i * DIGEST_BYTES_PER_ELEMENT;
+		let bytes: [u8; 8] = input[start..start + 8].try_into().expect("8 bytes");
+		Goldilocks::from_u64(u64::from_le_bytes(bytes))
+	})
+}
+
 // ============================================================================
 // Compact encoding (8 bytes/felt) for variable-length data
 // ============================================================================
@@ -428,6 +458,27 @@ mod tests {
 			let felts = bytes_to_felts(&original);
 			let reconstructed = felts_to_bytes(&felts).unwrap();
 			assert_eq!(original, reconstructed);
+		}
+	}
+
+	#[test]
+	fn test_bytes_to_u64s_iter_reports_exact_size() {
+		for input_len in 0..=17 {
+			let input = vec![0xA5u8; input_len];
+			let mut iter = bytes_to_u64s_iter(&input);
+
+			let expected_len = (input_len + 1).div_ceil(BYTES_PER_FELT);
+			assert_eq!(iter.len(), expected_len, "input len {input_len}");
+			assert_eq!(iter.size_hint(), (expected_len, Some(expected_len)));
+
+			// The hint must stay exact as the iterator is consumed.
+			let mut remaining = expected_len;
+			while iter.next().is_some() {
+				remaining -= 1;
+				assert_eq!(iter.len(), remaining, "input len {input_len}");
+			}
+			assert_eq!(remaining, 0);
+			assert_eq!(iter.size_hint(), (0, Some(0)));
 		}
 	}
 
@@ -572,6 +623,24 @@ mod tests {
 		digest[..8].copy_from_slice(&P.to_le_bytes());
 		let result = bytes_to_digest(&digest);
 		assert_eq!(result, Err("Digest limb exceeds Goldilocks modulus"));
+	}
+
+	#[test]
+	fn test_bytes_to_digest_lossy_matches_strict_on_canonical_input() {
+		let digest = [42u8; 32];
+		assert_eq!(bytes_to_digest_lossy(&digest), bytes_to_digest(&digest).unwrap());
+	}
+
+	#[test]
+	fn test_bytes_to_digest_lossy_reduces_non_canonical_limb() {
+		// The lossy variant deliberately accepts non-canonical limbs, reducing
+		// them mod P: a limb of P aliases with a limb of 0. This documents the
+		// non-injectivity that callers of the lossy API are opting into.
+		let canonical = [0u8; 32];
+		let mut aliased = canonical;
+		aliased[..8].copy_from_slice(&P.to_le_bytes());
+
+		assert_eq!(bytes_to_digest_lossy(&aliased), bytes_to_digest_lossy(&canonical));
 	}
 
 	#[test]

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -88,14 +88,17 @@ pub fn u128_to_felts(num: u128) -> [Goldilocks; FELTS_PER_U128] {
 	result
 }
 
-pub fn u128_to_quantized_felt(num: u128) -> Goldilocks {
+/// Quantize an amount and convert it to a field element.
+///
+/// Divides by [`AMOUNT_QUANTIZATION_FACTOR`] and returns an error if the quantized
+/// value does not fit a 32-bit limb. Inverse of [`try_felt_to_quantized_u128`].
+pub fn try_u128_to_quantized_felt(num: u128) -> Result<Goldilocks, String> {
 	let quantized = num / AMOUNT_QUANTIZATION_FACTOR;
-	assert!(
-		quantized <= BIT_32_LIMB_MASK as u128,
-		"Quantized value {} exceeds 32-bit limb size",
-		quantized
-	);
-	from_u64(quantized as u64)
+	if quantized <= BIT_32_LIMB_MASK as u128 {
+		Ok(from_u64(quantized as u64))
+	} else {
+		Err(alloc::format!("Quantized value {} exceeds 32-bit limb size", quantized))
+	}
 }
 
 pub fn u64_to_felts(num: u64) -> [Goldilocks; FELTS_PER_U64] {
@@ -472,7 +475,7 @@ mod tests {
 		let test_values = vec![0u128, 1_000_000_000_000u128, 21_000_000_000_000_000_000u128];
 
 		for &original in &test_values {
-			let felt = u128_to_quantized_felt(original);
+			let felt = try_u128_to_quantized_felt(original).unwrap();
 			let reconstructed = try_felt_to_quantized_u128(felt).unwrap();
 			let expected = original - (original % AMOUNT_QUANTIZATION_FACTOR);
 			assert_eq!(reconstructed, expected);
@@ -480,10 +483,11 @@ mod tests {
 	}
 
 	#[test]
-	#[should_panic(expected = "exceeds 32-bit limb size")]
-	fn test_u128_to_quantized_felt_panics_when_quantized_exceeds_32bit() {
+	fn test_try_u128_to_quantized_felt_rejects_oversized_value() {
 		let just_over = (BIT_32_LIMB_MASK as u128 + 1) * AMOUNT_QUANTIZATION_FACTOR;
-		let _ = u128_to_quantized_felt(just_over);
+		let result = try_u128_to_quantized_felt(just_over);
+		assert!(result.is_err(), "quantized value above 32-bit limb should be rejected");
+		assert!(result.unwrap_err().contains("exceeds 32-bit limb size"));
 	}
 
 	#[test]

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -207,8 +207,8 @@ impl<'a> Iterator for BytesToU64sIter<'a> {
 	fn size_hint(&self) -> (usize, Option<usize>) {
 		// Remaining full 4-byte chunks, plus the terminator word (which also
 		// carries any final partial chunk) if not yet emitted.
-		let remaining = (self.input.len() - self.pos) / BYTES_PER_FELT
-			+ usize::from(!self.emitted_terminator);
+		let remaining =
+			(self.input.len() - self.pos) / BYTES_PER_FELT + usize::from(!self.emitted_terminator);
 		(remaining, Some(remaining))
 	}
 }

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -4,8 +4,8 @@
 //!
 //! ## API Overview
 //!
-//! - `bytes_to_felts` / `bytes_to_felts_iter` / `felts_to_bytes` - Variable-length byte arrays
-//!   (4 bytes/felt + terminator) collision-resistant)
+//! - `bytes_to_felts` / `bytes_to_felts_iter` / `felts_to_bytes` - Variable-length byte arrays (4
+//!   bytes/felt + terminator) collision-resistant)
 //! - `digest_to_bytes` / `bytes_to_digest` - Hash output (4 felts ↔ 32 bytes, 8 bytes/felt)
 //!
 //! The 4-bytes/felt encoding is injective (collision-resistant) for arbitrary byte data.

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -13,7 +13,10 @@
 
 use alloc::{string::String, vec::Vec};
 
-use crate::{goldilocks::Goldilocks, poseidon2::POSEIDON2_OUTPUT};
+use crate::{
+	goldilocks::{Goldilocks, P},
+	poseidon2::POSEIDON2_OUTPUT,
+};
 
 const BIT_32_LIMB_MASK: u64 = 0xFFFF_FFFF;
 
@@ -37,6 +40,19 @@ pub const BYTES_PER_FELT: usize = 4;
 #[inline]
 fn from_u64(x: u64) -> Goldilocks {
 	Goldilocks::from_u64(x)
+}
+
+/// Convert a raw u64 limb into a field element, rejecting non-canonical encodings.
+///
+/// Values `>= P` alias with `value - P` inside the field, so accepting them would
+/// let byte-distinct inputs decode to the same field element (collision).
+#[inline]
+fn try_canonical_limb(x: u64, err: &'static str) -> Result<Goldilocks, &'static str> {
+	if x < P {
+		Ok(Goldilocks::from_u64(x))
+	} else {
+		Err(err)
+	}
 }
 
 #[inline]
@@ -283,14 +299,23 @@ pub fn digest_to_bytes(input: &[Goldilocks; POSEIDON2_OUTPUT]) -> BytesDigest {
 
 /// Convert 32 bytes to a digest (4 field elements).
 ///
-/// Each 8-byte chunk becomes one field element.
+/// Each 8-byte chunk becomes one canonical field element.
+/// Returns an error if any chunk encodes a value greater than or equal to the
+/// Goldilocks modulus, since such values would alias with a canonical element.
 /// Use this to deserialize hash outputs from storage.
-pub fn bytes_to_digest(input: &BytesDigest) -> [Goldilocks; POSEIDON2_OUTPUT] {
-	core::array::from_fn(|i| {
-		let start = i * 8;
+pub fn bytes_to_digest(
+	input: &BytesDigest,
+) -> Result<[Goldilocks; POSEIDON2_OUTPUT], &'static str> {
+	let mut out = [Goldilocks::ZERO; POSEIDON2_OUTPUT];
+	for (i, felt) in out.iter_mut().enumerate() {
+		let start = i * DIGEST_BYTES_PER_ELEMENT;
 		let bytes: [u8; 8] = input[start..start + 8].try_into().expect("8 bytes");
-		Goldilocks::from_u64(u64::from_le_bytes(bytes))
-	})
+		*felt = try_canonical_limb(
+			u64::from_le_bytes(bytes),
+			"Digest limb exceeds Goldilocks modulus",
+		)?;
+	}
+	Ok(out)
 }
 
 // ============================================================================
@@ -308,14 +333,20 @@ pub fn bytes_to_digest(input: &BytesDigest) -> [Goldilocks; POSEIDON2_OUTPUT] {
 /// - The input length is fixed/known, OR
 /// - Collision resistance is provided by other means (e.g., trie structure)
 ///
+/// Returns an error if any 8-byte chunk encodes a value greater than or equal to
+/// the Goldilocks modulus, since such values would alias with a canonical element.
+///
 /// # Example
 /// ```
 /// use qp_poseidon_core::serialization::bytes_to_felts_compact;
-/// let felts = bytes_to_felts_compact(b"hello world!"); // 12 bytes -> 2 felts
+/// let felts = bytes_to_felts_compact(b"hello world!").unwrap(); // 12 bytes -> 2 felts
 /// assert_eq!(felts.len(), 2);
 /// ```
-pub fn bytes_to_felts_compact(input: &[u8]) -> Vec<Goldilocks> {
-	bytes_to_u64s_compact(input).into_iter().map(from_u64).collect()
+pub fn bytes_to_felts_compact(input: &[u8]) -> Result<Vec<Goldilocks>, &'static str> {
+	bytes_to_u64s_compact(input)
+		.into_iter()
+		.map(|v| try_canonical_limb(v, "Compact encoding limb exceeds Goldilocks modulus"))
+		.collect()
 }
 
 /// Convert variable-length bytes to u64 values using compact encoding (8 bytes per element).
@@ -478,7 +509,7 @@ mod tests {
 	#[test]
 	fn test_digest_4felts_round_trip() {
 		let original = [42u8; 32];
-		let felts: [Goldilocks; POSEIDON2_OUTPUT] = bytes_to_digest(&original);
+		let felts: [Goldilocks; POSEIDON2_OUTPUT] = bytes_to_digest(&original).unwrap();
 		let reconstructed = digest_to_bytes(&felts);
 		assert_eq!(original, reconstructed);
 	}
@@ -486,7 +517,7 @@ mod tests {
 	#[test]
 	fn test_digest_4felts_uses_4_felts() {
 		let original = [42u8; 32];
-		let felts: [Goldilocks; POSEIDON2_OUTPUT] = bytes_to_digest(&original);
+		let felts: [Goldilocks; POSEIDON2_OUTPUT] = bytes_to_digest(&original).unwrap();
 		assert_eq!(felts.len(), POSEIDON2_OUTPUT);
 	}
 
@@ -494,25 +525,25 @@ mod tests {
 	fn test_bytes_to_felts_compact_sizing() {
 		// Empty input -> empty output
 		let empty: [u8; 0] = [];
-		assert_eq!(bytes_to_felts_compact(&empty).len(), 0);
+		assert_eq!(bytes_to_felts_compact(&empty).unwrap().len(), 0);
 
 		// 1-8 bytes -> 1 felt
-		assert_eq!(bytes_to_felts_compact(&[1u8]).len(), 1);
-		assert_eq!(bytes_to_felts_compact(&[1u8; 8]).len(), 1);
+		assert_eq!(bytes_to_felts_compact(&[1u8]).unwrap().len(), 1);
+		assert_eq!(bytes_to_felts_compact(&[1u8; 8]).unwrap().len(), 1);
 
 		// 9-16 bytes -> 2 felts
-		assert_eq!(bytes_to_felts_compact(&[1u8; 9]).len(), 2);
-		assert_eq!(bytes_to_felts_compact(&[1u8; 16]).len(), 2);
+		assert_eq!(bytes_to_felts_compact(&[1u8; 9]).unwrap().len(), 2);
+		assert_eq!(bytes_to_felts_compact(&[1u8; 16]).unwrap().len(), 2);
 
 		// 32 bytes -> 4 felts (same as POSEIDON2_OUTPUT)
-		assert_eq!(bytes_to_felts_compact(&[1u8; 32]).len(), 4);
+		assert_eq!(bytes_to_felts_compact(&[1u8; 32]).unwrap().len(), 4);
 	}
 
 	#[test]
 	fn test_bytes_to_felts_compact_content() {
 		// Verify the encoding is correct
 		let input = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
-		let felts = bytes_to_felts_compact(&input);
+		let felts = bytes_to_felts_compact(&input).unwrap();
 		assert_eq!(felts.len(), 1);
 
 		// Should be little-endian u64
@@ -521,10 +552,24 @@ mod tests {
 	}
 
 	#[test]
+	fn test_bytes_to_felts_compact_rejects_non_canonical_limb() {
+		let result = bytes_to_felts_compact(&P.to_le_bytes());
+		assert_eq!(result, Err("Compact encoding limb exceeds Goldilocks modulus"));
+	}
+
+	#[test]
+	fn test_bytes_to_digest_rejects_non_canonical_limb() {
+		let mut digest = [0u8; 32];
+		digest[..8].copy_from_slice(&P.to_le_bytes());
+		let result = bytes_to_digest(&digest);
+		assert_eq!(result, Err("Digest limb exceeds Goldilocks modulus"));
+	}
+
+	#[test]
 	fn test_bytes_to_felts_compact_vs_injective() {
 		// Compact encoding should produce fewer felts than injective encoding
 		let input = [42u8; 32];
-		let compact = bytes_to_felts_compact(&input);
+		let compact = bytes_to_felts_compact(&input).unwrap();
 		let injective = bytes_to_felts(&input);
 
 		// 32 bytes: compact = 4 felts, injective = 9 felts (8 data + 1 terminator)

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -4,8 +4,8 @@
 //!
 //! ## API Overview
 //!
-//! - `bytes_to_felts` / `felts_to_bytes` - Variable-length byte arrays (4 bytes/felt + terminator)
-//!   collision-resistant)
+//! - `bytes_to_felts` / `bytes_to_felts_iter` / `felts_to_bytes` - Variable-length byte arrays
+//!   (4 bytes/felt + terminator) collision-resistant)
 //! - `digest_to_bytes` / `bytes_to_digest` - Hash output (4 felts ↔ 32 bytes, 8 bytes/felt)
 //!
 //! The 4-bytes/felt encoding is injective (collision-resistant) for arbitrary byte data.
@@ -113,6 +113,15 @@ pub fn try_felts_to_u64(felts: [Goldilocks; FELTS_PER_U64]) -> Result<u64, Strin
 // Variable-length bytes <-> felts
 // ============================================================================
 
+/// Lazily encode bytes into field elements (4 bytes/felt + terminator).
+///
+/// This is the single source of truth for the injective byte encoding. Use this
+/// when you want to consume felts incrementally (e.g. sponge absorption) without
+/// allocating a `Vec`. For an owned vector, use [`bytes_to_felts`].
+pub fn bytes_to_felts_iter(input: &[u8]) -> impl Iterator<Item = Goldilocks> + '_ {
+	bytes_to_u64s_iter(input).map(from_u64)
+}
+
 /// Convert variable-length bytes to field elements.
 ///
 /// Uses 4 bytes per field element with a terminator marker (0x01) appended,
@@ -125,7 +134,7 @@ pub fn try_felts_to_u64(felts: [Goldilocks; FELTS_PER_U64]) -> Result<u64, Strin
 /// assert_eq!(felts.len(), 2); // 5 bytes + terminator = 6 bytes -> ceil(6/4) = 2 felts
 /// ```
 pub fn bytes_to_felts(input: &[u8]) -> Vec<Goldilocks> {
-	bytes_to_u64s(input).into_iter().map(from_u64).collect()
+	bytes_to_felts_iter(input).collect()
 }
 
 /// Convert field elements back to variable-length bytes.
@@ -146,27 +155,45 @@ pub fn string_to_felts(input: &str) -> Vec<Goldilocks> {
 // Core u64-based functions (field-type agnostic)
 // ============================================================================
 
+/// Iterator over u64 limbs produced by the injective 4-byte encoding.
+pub struct BytesToU64sIter<'a> {
+	input: &'a [u8],
+	pos: usize,
+	emitted_terminator: bool,
+}
+
+impl<'a> Iterator for BytesToU64sIter<'a> {
+	type Item = u64;
+
+	fn next(&mut self) -> Option<Self::Item> {
+		if self.pos + BYTES_PER_FELT <= self.input.len() {
+			let chunk = &self.input[self.pos..self.pos + BYTES_PER_FELT];
+			self.pos += BYTES_PER_FELT;
+			let bytes = [chunk[0], chunk[1], chunk[2], chunk[3]];
+			return Some(u32::from_le_bytes(bytes) as u64);
+		}
+
+		if self.emitted_terminator {
+			return None;
+		}
+
+		self.emitted_terminator = true;
+		let remainder = &self.input[self.pos..];
+		let mut last = [0u8; BYTES_PER_FELT];
+		last[..remainder.len()].copy_from_slice(remainder);
+		last[remainder.len()] = 1u8;
+		Some(u32::from_le_bytes(last) as u64)
+	}
+}
+
+/// Lazily encode bytes into u64 limbs (4 bytes per element + terminator).
+pub fn bytes_to_u64s_iter(input: &[u8]) -> BytesToU64sIter<'_> {
+	BytesToU64sIter { input, pos: 0, emitted_terminator: false }
+}
+
 /// Convert variable-length bytes to u64 values (4 bytes per element + terminator).
 pub fn bytes_to_u64s(input: &[u8]) -> Vec<u64> {
-	let input_len = input.len();
-	let len_with_marker = input_len + 1;
-	let padding_needed = (BYTES_PER_FELT - (len_with_marker % BYTES_PER_FELT)) % BYTES_PER_FELT;
-	let final_padded_size = len_with_marker + padding_needed;
-	let num_elements = final_padded_size / BYTES_PER_FELT;
-
-	let mut padded_input = Vec::<u8>::with_capacity(final_padded_size);
-	let mut out = Vec::<u64>::with_capacity(num_elements);
-
-	padded_input.extend_from_slice(input);
-	padded_input.push(1u8); // terminator marker
-	padded_input.resize(final_padded_size, 0u8);
-
-	for chunk in padded_input.chunks_exact(BYTES_PER_FELT) {
-		let bytes = [chunk[0], chunk[1], chunk[2], chunk[3]];
-		out.push(u32::from_le_bytes(bytes) as u64);
-	}
-
-	out
+	bytes_to_u64s_iter(input).collect()
 }
 
 /// Convert u64 values back to bytes (inverse of `bytes_to_u64s`).
@@ -362,6 +389,28 @@ mod tests {
 			let felts = bytes_to_felts(&original);
 			let reconstructed = felts_to_bytes(&felts).unwrap();
 			assert_eq!(original, reconstructed);
+		}
+	}
+
+	#[test]
+	fn test_bytes_to_felts_iter_matches_collecting_api() {
+		let test_cases = vec![
+			vec![],
+			vec![0u8],
+			vec![1u8, 2, 3, 4],
+			vec![1u8, 2, 3, 4, 5],
+			vec![255u8; 32],
+			b"hello world".to_vec(),
+		];
+
+		for input in test_cases {
+			let collected = bytes_to_felts(&input);
+			let iterated: Vec<_> = bytes_to_felts_iter(&input).collect();
+			assert_eq!(collected, iterated, "input len {}", input.len());
+
+			let collected_u64s = bytes_to_u64s(&input);
+			let iterated_u64s: Vec<_> = bytes_to_u64s_iter(&input).collect();
+			assert_eq!(collected_u64s, iterated_u64s, "input len {}", input.len());
 		}
 	}
 

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -272,14 +272,19 @@ pub fn digest_to_u64s(input: &BytesDigest) -> [u64; DIGEST_NUM_FELTS] {
 }
 
 /// Convert 8 u64 values to 32-byte digest (inverse of `digest_to_u64s`).
-pub fn u64s_to_digest(input: &[u64; DIGEST_NUM_FELTS]) -> BytesDigest {
+///
+/// Each limb occupies 4 bytes on the wire, so limbs must fit in 32 bits.
+/// Returns an error for oversized limbs instead of silently truncating them,
+/// which would let distinct limb arrays alias to the same digest.
+pub fn u64s_to_digest(input: &[u64; DIGEST_NUM_FELTS]) -> Result<BytesDigest, &'static str> {
 	let mut bytes = [0u8; 32];
-	for (i, v) in input.iter().enumerate() {
+	for (i, &v) in input.iter().enumerate() {
+		let _ = as_32_bit_limb_u64(v, i).map_err(|_| "Digest limb exceeds 32 bits")?;
 		let start = i * BYTES_PER_FELT;
 		let end = start + BYTES_PER_FELT;
-		bytes[start..end].copy_from_slice(&(*v as u32).to_le_bytes());
+		bytes[start..end].copy_from_slice(&(v as u32).to_le_bytes());
 	}
-	bytes
+	Ok(bytes)
 }
 
 // ============================================================================

--- a/tests/alloc_bounds.rs
+++ b/tests/alloc_bounds.rs
@@ -1,0 +1,119 @@
+//! Regression tests for audit finding #96388 "Unbounded byte-hash allocation".
+//!
+//! The public byte-hashing entrypoints (`hash_bytes`, `hash_squeeze_twice`) must not
+//! materialize heap buffers proportional to the input size before absorbing: the
+//! sponge can absorb incrementally, so byte hashing should use O(1) extra heap.
+
+use qp_poseidon_core::{hash_bytes, hash_squeeze_twice, hash_to_bytes};
+use qp_poseidon_core::serialization::bytes_to_felts;
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::hint::black_box;
+use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+use std::sync::Mutex;
+
+struct TrackingAllocator;
+
+static CURRENT_ALLOCATED: AtomicUsize = AtomicUsize::new(0);
+static PEAK_ALLOCATED: AtomicUsize = AtomicUsize::new(0);
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: TrackingAllocator = TrackingAllocator;
+
+// Serializes entire test bodies: allocations from a concurrently running test would
+// otherwise pollute the peak counter.
+static MEASURE_LOCK: Mutex<()> = Mutex::new(());
+
+#[inline]
+fn record_alloc(size: usize) {
+	let new_total = CURRENT_ALLOCATED.fetch_add(size, SeqCst) + size;
+	PEAK_ALLOCATED.fetch_max(new_total, SeqCst);
+}
+
+#[inline]
+fn record_dealloc(size: usize) {
+	CURRENT_ALLOCATED.fetch_sub(size, SeqCst);
+}
+
+unsafe impl GlobalAlloc for TrackingAllocator {
+	unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+		let ptr = System.alloc(layout);
+		if !ptr.is_null() {
+			record_alloc(layout.size());
+		}
+		ptr
+	}
+
+	unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+		let ptr = System.alloc_zeroed(layout);
+		if !ptr.is_null() {
+			record_alloc(layout.size());
+		}
+		ptr
+	}
+
+	unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+		record_dealloc(layout.size());
+		System.dealloc(ptr, layout);
+	}
+
+	unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+		let new_ptr = System.realloc(ptr, layout, new_size);
+		if !new_ptr.is_null() {
+			if new_size >= layout.size() {
+				record_alloc(new_size - layout.size());
+			} else {
+				record_dealloc(layout.size() - new_size);
+			}
+		}
+		new_ptr
+	}
+}
+
+/// Runs `f` and returns its result plus the peak heap growth (in bytes) observed while it ran.
+/// Caller must hold `MEASURE_LOCK`.
+fn measure_peak_delta<T>(f: impl FnOnce() -> T) -> (T, usize) {
+	let baseline = CURRENT_ALLOCATED.load(SeqCst);
+	PEAK_ALLOCATED.store(baseline, SeqCst);
+	let result = f();
+	let peak = PEAK_ALLOCATED.load(SeqCst);
+	(result, peak.saturating_sub(baseline))
+}
+
+const INPUT_LEN: usize = 256 * 1024;
+
+/// Generous O(1) budget: streaming absorption needs no proportional heap at all,
+/// but allow a small constant for incidental allocations.
+const CONSTANT_HEAP_BUDGET: usize = 4096;
+
+#[test]
+fn hash_bytes_uses_constant_heap() {
+	let _guard = MEASURE_LOCK.lock().unwrap();
+	let input = vec![0x41u8; INPUT_LEN];
+
+	// The digest must stay identical to the felt-path reference.
+	let expected_digest = hash_to_bytes(&bytes_to_felts(&input));
+
+	let (digest, peak) = measure_peak_delta(|| hash_bytes(black_box(&input)));
+
+	assert_eq!(digest, expected_digest, "hash_bytes digest must not change");
+	assert!(
+		peak <= CONSTANT_HEAP_BUDGET,
+		"hash_bytes should absorb bytes incrementally without materializing the \
+		 serialized preimage; input was {INPUT_LEN} bytes but peak heap growth was {peak} bytes"
+	);
+}
+
+#[test]
+fn hash_squeeze_twice_uses_constant_heap() {
+	let _guard = MEASURE_LOCK.lock().unwrap();
+	let input = vec![0x24u8; INPUT_LEN];
+
+	let (digest64, peak) = measure_peak_delta(|| hash_squeeze_twice(black_box(&input)));
+
+	assert_eq!(digest64.len(), 64);
+	assert!(
+		peak <= CONSTANT_HEAP_BUDGET,
+		"hash_squeeze_twice should absorb bytes incrementally without materializing the \
+		 serialized preimage; input was {INPUT_LEN} bytes but peak heap growth was {peak} bytes"
+	);
+}

--- a/tests/alloc_bounds.rs
+++ b/tests/alloc_bounds.rs
@@ -4,12 +4,17 @@
 //! materialize heap buffers proportional to the input size before absorbing: the
 //! sponge can absorb incrementally, so byte hashing should use O(1) extra heap.
 
-use qp_poseidon_core::{hash_bytes, hash_squeeze_twice, hash_to_bytes};
-use qp_poseidon_core::serialization::bytes_to_felts;
-use std::alloc::{GlobalAlloc, Layout, System};
-use std::hint::black_box;
-use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
-use std::sync::Mutex;
+use qp_poseidon_core::{
+	hash_bytes, hash_squeeze_twice, hash_to_bytes, serialization::bytes_to_felts,
+};
+use std::{
+	alloc::{GlobalAlloc, Layout, System},
+	hint::black_box,
+	sync::{
+		atomic::{AtomicUsize, Ordering::SeqCst},
+		Mutex,
+	},
+};
 
 struct TrackingAllocator;
 

--- a/tests/alloc_bounds.rs
+++ b/tests/alloc_bounds.rs
@@ -75,13 +75,20 @@ unsafe impl GlobalAlloc for TrackingAllocator {
 }
 
 /// Runs `f` and returns its result plus the peak heap growth (in bytes) observed while it ran.
-/// Caller must hold `MEASURE_LOCK`.
-fn measure_peak_delta<T>(f: impl FnOnce() -> T) -> (T, usize) {
-	let baseline = CURRENT_ALLOCATED.load(SeqCst);
-	PEAK_ALLOCATED.store(baseline, SeqCst);
-	let result = f();
-	let peak = PEAK_ALLOCATED.load(SeqCst);
-	(result, peak.saturating_sub(baseline))
+/// Caller must hold `MEASURE_LOCK`. Takes the minimum over several runs: `f` is deterministic,
+/// so the minimum converges to its true peak while filtering out concurrent allocations from
+/// libtest harness threads.
+fn measure_peak_delta<T>(f: impl Fn() -> T) -> (T, usize) {
+	let mut best_peak = usize::MAX;
+	let mut result = None;
+	for _ in 0..5 {
+		let baseline = CURRENT_ALLOCATED.load(SeqCst);
+		PEAK_ALLOCATED.store(baseline, SeqCst);
+		result = Some(f());
+		let peak = PEAK_ALLOCATED.load(SeqCst);
+		best_peak = best_peak.min(peak.saturating_sub(baseline));
+	}
+	(result.expect("ran at least once"), best_peak)
 }
 
 const INPUT_LEN: usize = 256 * 1024;

--- a/tests/digest_limb_truncation.rs
+++ b/tests/digest_limb_truncation.rs
@@ -5,8 +5,10 @@
 //! limb arrays aliased to the same serialized digest. Oversized limbs are now
 //! rejected, matching the adjacent `u64s_to_bytes` serializer.
 
-use qp_poseidon_core::hash_bytes;
-use qp_poseidon_core::serialization::{digest_to_u64s, u64s_to_digest};
+use qp_poseidon_core::{
+	hash_bytes,
+	serialization::{digest_to_u64s, u64s_to_digest},
+};
 
 #[test]
 fn oversized_limbs_are_rejected_instead_of_aliasing() {

--- a/tests/digest_limb_truncation.rs
+++ b/tests/digest_limb_truncation.rs
@@ -1,0 +1,35 @@
+//! Regression tests for audit finding #96397 "Digest limbs silently truncate".
+//!
+//! `u64s_to_digest` takes eight u64 limbs, but the wire format only holds 32 bits
+//! per limb. Narrowing with `as u32` silently discarded the high bits, so distinct
+//! limb arrays aliased to the same serialized digest. Oversized limbs are now
+//! rejected, matching the adjacent `u64s_to_bytes` serializer.
+
+use qp_poseidon_core::hash_bytes;
+use qp_poseidon_core::serialization::{digest_to_u64s, u64s_to_digest};
+
+#[test]
+fn oversized_limbs_are_rejected_instead_of_aliasing() {
+	let canonical_wire_digest = hash_bytes(b"authorization-boundary-example");
+	let canonical_limbs = digest_to_u64s(&canonical_wire_digest);
+	assert!(canonical_limbs.iter().all(|v| *v <= 0xFFFF_FFFF));
+
+	let mut forged_limbs = canonical_limbs;
+	forged_limbs[1] |= 1u64 << 40;
+	forged_limbs[6] |= 0x55AAu64 << 32;
+	assert_ne!(forged_limbs, canonical_limbs);
+
+	assert_eq!(
+		u64s_to_digest(&forged_limbs),
+		Err("Digest limb exceeds 32 bits"),
+		"limbs exceeding 32 bits should be rejected, not silently truncated"
+	);
+}
+
+#[test]
+fn valid_limbs_round_trip() {
+	let digest = hash_bytes(b"round trip");
+	let limbs = digest_to_u64s(&digest);
+	let back = u64s_to_digest(&limbs).expect("canonical limbs should serialize");
+	assert_eq!(back, digest);
+}

--- a/tests/non_canonical_limbs.rs
+++ b/tests/non_canonical_limbs.rs
@@ -1,0 +1,49 @@
+//! Regression tests for audit finding #96398 "Non-canonical 8-byte limb decoding".
+//!
+//! Byte strings whose 8-byte limbs encode values `>= P` would alias with canonical
+//! field elements (`P` and `0` are the same element), letting byte-distinct inputs
+//! hash to identical outputs. The decoders must reject such inputs.
+
+use qp_poseidon_core::goldilocks::P;
+use qp_poseidon_core::serialization::{bytes_to_digest, bytes_to_felts_compact, digest_to_bytes};
+use qp_poseidon_core::{hash_to_bytes, rehash_to_bytes, Goldilocks};
+
+#[test]
+fn bytes_to_digest_rejects_non_canonical_limb() {
+	let mut aliased_digest = [0u8; 32];
+	aliased_digest[..8].copy_from_slice(&P.to_le_bytes());
+	assert_eq!(bytes_to_digest(&aliased_digest), Err("Digest limb exceeds Goldilocks modulus"));
+}
+
+#[test]
+fn rehash_to_bytes_rejects_non_canonical_digest() {
+	let mut aliased_digest = [0u8; 32];
+	aliased_digest[..8].copy_from_slice(&P.to_le_bytes());
+	assert_eq!(rehash_to_bytes(&aliased_digest), Err("Digest limb exceeds Goldilocks modulus"));
+}
+
+#[test]
+fn bytes_to_felts_compact_rejects_non_canonical_limb() {
+	assert_eq!(
+		bytes_to_felts_compact(&P.to_le_bytes()),
+		Err("Compact encoding limb exceeds Goldilocks modulus")
+	);
+}
+
+#[test]
+fn canonical_digest_roundtrip_and_rehash_remain_stable() {
+	let canonical_digest = digest_to_bytes(&[Goldilocks::ZERO; 4]);
+	let decoded = bytes_to_digest(&canonical_digest).unwrap();
+	assert_eq!(digest_to_bytes(&decoded), canonical_digest);
+
+	let rehashed = rehash_to_bytes(&canonical_digest).unwrap();
+	let rehashed_again = rehash_to_bytes(&canonical_digest).unwrap();
+	assert_eq!(rehashed, rehashed_again);
+}
+
+#[test]
+fn canonical_compact_encoding_still_hashes() {
+	let canonical_felts = bytes_to_felts_compact(&[0u8; 8]).unwrap();
+	let hash = hash_to_bytes(&canonical_felts);
+	assert_eq!(hash.len(), 32);
+}

--- a/tests/non_canonical_limbs.rs
+++ b/tests/non_canonical_limbs.rs
@@ -4,9 +4,12 @@
 //! field elements (`P` and `0` are the same element), letting byte-distinct inputs
 //! hash to identical outputs. The decoders must reject such inputs.
 
-use qp_poseidon_core::goldilocks::P;
-use qp_poseidon_core::serialization::{bytes_to_digest, bytes_to_felts_compact, digest_to_bytes};
-use qp_poseidon_core::{hash_to_bytes, rehash_to_bytes, Goldilocks};
+use qp_poseidon_core::{
+	goldilocks::P,
+	hash_to_bytes, rehash_to_bytes,
+	serialization::{bytes_to_digest, bytes_to_felts_compact, digest_to_bytes},
+	Goldilocks,
+};
 
 #[test]
 fn bytes_to_digest_rejects_non_canonical_limb() {

--- a/tests/quantized_amount.rs
+++ b/tests/quantized_amount.rs
@@ -1,0 +1,36 @@
+//! Regression tests for audit finding #96399 "Public amount conversion panics on
+//! oversized inputs".
+//!
+//! Converting an untrusted amount must be a recoverable validation failure, not a
+//! panic: a single oversized value in a batch would otherwise unwind (or abort under
+//! panic=abort) instead of being rejected cleanly.
+
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+use qp_poseidon_core::serialization::{
+	try_felt_to_quantized_u128, try_u128_to_quantized_felt, AMOUNT_QUANTIZATION_FACTOR,
+};
+
+/// Largest amount whose quantized value still fits a 32-bit limb.
+fn max_supported_amount() -> u128 {
+	(u32::MAX as u128) * AMOUNT_QUANTIZATION_FACTOR
+}
+
+#[test]
+fn oversized_amount_is_rejected_without_panicking() {
+	let oversized = max_supported_amount() + AMOUNT_QUANTIZATION_FACTOR;
+
+	let outcome = catch_unwind(AssertUnwindSafe(|| try_u128_to_quantized_felt(oversized)));
+
+	let result = outcome.expect("conversion of an oversized amount must not panic");
+	assert!(result.is_err(), "oversized amount should be rejected with a recoverable error");
+}
+
+#[test]
+fn valid_amounts_round_trip() {
+	for amount in [0u128, AMOUNT_QUANTIZATION_FACTOR, max_supported_amount()] {
+		let felt = try_u128_to_quantized_felt(amount).expect("in-range amount should convert");
+		let back = try_felt_to_quantized_u128(felt).expect("round trip");
+		assert_eq!(back, amount - (amount % AMOUNT_QUANTIZATION_FACTOR));
+	}
+}


### PR DESCRIPTION
# Address V12 audit findings (v12 report)

Fixes all six findings from the V12 audit. Each fix landed as its own commit with a regression test confirming the issue before the fix was applied.

## Security fixes

**Unbounded byte-hash allocation (#96388, Medium)** — `hash_bytes` and `hash_squeeze_twice` materialized the entire serialized preimage (~3x input size across three heap buffers) before absorbing into the sponge, allowing memory-amplification DoS on attacker-sized inputs. Byte absorption now streams 4-byte chunks directly into the sponge via a new shared `bytes_to_felts_iter` / `bytes_to_u64s_iter` encoding iterator, keeping heap usage O(1) while producing byte-identical digests (verified against existing known-answer vectors).

**Non-canonical 8-byte limb decoding (#96398, Medium)** — `bytes_to_digest` and `bytes_to_felts_compact` accepted raw u64 limbs without checking `value < P`. Since `P` and `0` are the same Goldilocks element, byte-distinct inputs (e.g. a limb of `P` vs `0`) decoded to identical felts and collided under `rehash_to_bytes` and compact hashing. These decoders now reject non-canonical limbs.

**Panicking amount conversion (#96399, Medium)** — `u128_to_quantized_felt` panicked via `assert!` on amounts whose quantized value exceeds 32 bits, turning input validation into a DoS vector (especially under `panic=abort`). Replaced by `try_u128_to_quantized_felt`, which returns a recoverable error, mirroring the existing reverse conversion.

**Digest limb truncation (#96397, Low)** — `u64s_to_digest` narrowed each u64 limb with `as u32`, silently discarding high bits so distinct limb arrays aliased to the same wire digest. It now rejects limbs exceeding 32 bits.

**Benchmark discards timed outputs (#96386, Low)** — every timed closure in the dudect constant-time harness (`examples/ct_bench.rs`) discarded its result, permitting the optimizer to elide the very work being measured. All inputs and outputs are now routed through `black_box`.

**Constant-time documentation (#96400, Medium, audit PoC marked invalid)** — the README claimed "no input-dependent branches," but Goldilocks add/sub/reduce contain rare carry/borrow correction branches (standard optimized Goldilocks arithmetic, as in plonky2/plonky3). The audit's own measurements found no exploitable timing distinguisher, so rather than a risky branchless rewrite, the claim is narrowed: dudect results are empirical evidence of no measurable leakage, not a branch-free guarantee.

## Breaking API changes

Decoding/parsing functions at trust boundaries are now fallible, consistent with the existing `try_*` / `Result` conventions in the crate:

| Function | Before | After |
|---|---|---|
| `bytes_to_digest` | infallible | `Result` — rejects limbs `>= P` |
| `bytes_to_felts_compact` | infallible | `Result` — rejects limbs `>= P` |
| `rehash_to_bytes` | infallible | `Result` — propagates digest decode errors |
| `u128_to_quantized_felt` | panics when oversized | renamed `try_u128_to_quantized_felt`, returns `Result` |
| `u64s_to_digest` | truncates silently | `Result` — rejects limbs `> u32::MAX` |

Digests produced by this library are always canonical, so well-behaved callers can `?`/`expect` these results. A semver-major release is warranted.

## Tests

Four new integration test files (`alloc_bounds`, `non_canonical_limbs`, `quantized_amount`, `digest_limb_truncation`) covering each finding, including a tracking-allocator harness asserting O(1) heap for byte hashing. Full suite: 72 tests passing, clippy clean, dudect harness verified running in release mode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking public APIs plus cryptographic parsing and hash-input handling changes; callers must handle `Result` and a major release is expected, though library-produced digests remain canonical.
> 
> **Overview**
> Addresses the V12 audit with **breaking** security and API hardening across hashing, serialization, and docs/tests.
> 
> **Hashing / DoS:** `hash_bytes` and `hash_squeeze_twice` no longer build a full serialized preimage on the heap; they stream the injective encoding via new `bytes_to_felts_iter` / `bytes_to_u64s_iter` into the sponge (O(1) extra heap, same digests). Integration tests use a tracking allocator to enforce that.
> 
> **Collision / validation at decode boundaries:** `bytes_to_digest`, `bytes_to_felts_compact`, and `rehash_to_bytes` now return `Result` and reject 8-byte limbs with value `>= P`. `u64s_to_digest` returns `Result` and rejects limbs wider than 32 bits instead of truncating. `u128_to_quantized_felt` is replaced by `try_u128_to_quantized_felt` (no panic on oversized amounts).
> 
> **Timing / docs:** `ct_bench` wraps measured work in `black_box`; README and `CONSTANT_TIME_TESTING.md` narrow constant-time claims to empirical dudect evidence (Goldilocks arithmetic is not strictly branch-free).
> 
> New regression tests cover allocation bounds, non-canonical limbs, digest truncation, and quantized amounts; changelog documents unreleased breaking changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 062e8275e8dfe88c732227b2ff709b9d5563e2d0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->