### PR TITLE
ci: Automate version bump to v3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "qp-poseidon-core"
-version = "2.1.0"
+version = "3.0.0"
 dependencies = [
  "criterion",
  "dudect-bencher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qp-poseidon-core"
-version = "2.1.0"
+version = "3.0.0"
 authors = ["Quantus Network Developers <hello@quantus.com>"]
 homepage = "https://quantus.com"
 repository = "https://github.com/Quantus-Network/qp-poseidon"


### PR DESCRIPTION
Automated version bump for release v3.0.0.

https://github.com/Quantus-Network/qp-poseidon/actions/runs/28918183714

Triggered by workflow run: major

Type: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump with no source changes; risk is limited to release tagging and downstream version pinning expectations for a major semver bump.
> 
> **Overview**
> Automated **major release** version bump for `qp-poseidon-core` from **2.1.0** to **3.0.0**.
> 
> Updates the package version in `Cargo.toml` and the matching `[[package]]` entry in `Cargo.lock`; no library or API code changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d43480e36508a7de3962da78272aba0741946142. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->