### PR TITLE
update crossbeam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
cargo audit thing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only patch bump of a transitive concurrency dependency (via rayon/crossbeam-deque) with no direct code changes.
> 
> **Overview**
> Bumps the **`crossbeam-epoch`** crate from **0.9.18** to **0.9.20** in **`Cargo.lock`** only (checksum updated accordingly). **`crossbeam-utils`** stays at **0.8.21**; no application source or **`Cargo.toml`** changes appear in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a96d229838f5c963fbdddb71ec7f3a83852d94a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->