### PR TITLE
ci: Automate version bump to v3.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "qp-poseidon-core"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "criterion",
  "dudect-bencher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qp-poseidon-core"
-version = "3.0.0"
+version = "3.0.1"
 authors = ["Quantus Network Developers <hello@quantus.com>"]
 homepage = "https://quantus.com"
 repository = "https://github.com/Quantus-Network/qp-poseidon"


### PR DESCRIPTION
Automated version bump for release v3.0.1.

https://github.com/Quantus-Network/qp-poseidon/actions/runs/29238298875

Triggered by workflow run: patch

Type: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump with no code or dependency changes.
> 
> **Overview**
> **Automated patch release** that bumps `qp-poseidon-core` from **3.0.0** to **3.0.1** in `Cargo.toml` and the matching `[[package]]` entry in `Cargo.lock`.
> 
> No source, dependency, or feature changes—only crate version metadata for publishing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9545430064a3f8975932ea0ee6dc4350047dc0dc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->