### PR TITLE
ci: Automate version bump to v3.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,7 +385,7 @@ dependencies = [
 
 [[package]]
 name = "qp-poseidon-core"
-version = "3.0.0"
+version = "3.0.2"
 dependencies = [
  "criterion",
  "dudect-bencher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qp-poseidon-core"
-version = "3.0.0"
+version = "3.0.2"
 authors = ["Quantus Network Developers <hello@quantus.com>"]
 homepage = "https://quantus.com"
 repository = "https://github.com/Quantus-Network/qp-poseidon"


### PR DESCRIPTION
Automated version bump for release v3.0.2.

https://github.com/Quantus-Network/qp-poseidon/actions/runs/29386202015

Triggered by workflow run: custom

Type: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version metadata only; no library or cryptographic implementation changes.
> 
> **Overview**
> Automated release version bump for **`qp-poseidon-core`** from **3.0.0** to **3.0.2**, updating **`Cargo.toml`** and the matching entry in **`Cargo.lock`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 652b332f40e0ef453421c606e750825626da6a47. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->