### PR TITLE
Wipe the sponge state after hashing so secrets don't linger on the stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73cd58deff2140a0a8eae87e417bd01db68a33e148aa93d1e8cd837e55e312b6"
+dependencies = [
+ "object",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,6 +84,16 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -237,6 +256,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +379,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,12 +418,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
+]
+
+[[package]]
 name = "qp-poseidon-core"
 version = "3.0.2"
 dependencies = [
  "criterion",
  "dudect-bencher",
  "hex",
+ "psm",
 ]
 
 [[package]]
@@ -511,6 +556,12 @@ dependencies = [
  "serde_core",
  "zmij",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ categories = ["cryptography", "no-std"]
 hex = "0.4.3"
 criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
 dudect-bencher = "0.6"
+# Painted-stack probe used by tests/stack_zeroization.rs.
+psm = "=0.1.31"
 
 [features]
 default = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,28 +86,34 @@ impl Poseidon2State {
 			.expect("POSEIDON2_OUTPUT <= SPONGE_WIDTH")
 	}
 
+	// The `_to_bytes` finalizers below pass `digest_to_bytes` a *borrowed*
+	// subarray of the state (`try_into` on a slice yields `&[Goldilocks; 4]`,
+	// a reference conversion with no copy) rather than an owned felt array:
+	// an owned intermediate would be one more digest copy on the stack for
+	// [`Self::wipe`] to miss.
 	fn finalize_to_bytes(&mut self) -> [u8; 32] {
 		self.finalize_state();
-		self.digest_bytes()
+		serialization::digest_to_bytes(
+			self.state[..POSEIDON2_OUTPUT]
+				.try_into()
+				.expect("POSEIDON2_OUTPUT <= SPONGE_WIDTH"),
+		)
 	}
 
 	fn finalize_squeeze_twice(&mut self) -> [u8; 64] {
 		self.finalize_state();
 		let mut out = [0u8; 64];
-		out[..32].copy_from_slice(&self.digest_bytes());
+		out[..32].copy_from_slice(&serialization::digest_to_bytes(
+			self.state[..POSEIDON2_OUTPUT]
+				.try_into()
+				.expect("POSEIDON2_OUTPUT <= SPONGE_WIDTH"),
+		));
 		self.poseidon2.permute_mut(&mut self.state);
-		out[32..].copy_from_slice(&self.digest_bytes());
-		out
-	}
-
-	/// Serialize the digest directly from the state (same encoding as
-	/// [`serialization::digest_to_bytes`]), without materializing an
-	/// intermediate felt array.
-	fn digest_bytes(&self) -> [u8; 32] {
-		let mut out = [0u8; 32];
-		for (chunk, felt) in out.chunks_exact_mut(8).zip(&self.state[..POSEIDON2_OUTPUT]) {
-			chunk.copy_from_slice(&felt.as_canonical_u64().to_le_bytes());
-		}
+		out[32..].copy_from_slice(&serialization::digest_to_bytes(
+			self.state[..POSEIDON2_OUTPUT]
+				.try_into()
+				.expect("POSEIDON2_OUTPUT second squeeze <= SPONGE_WIDTH"),
+		));
 		out
 	}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,43 +60,81 @@ impl Poseidon2State {
 		}
 	}
 
-	fn finalize_state(mut self) -> [Goldilocks; SPONGE_WIDTH] {
+	/// Pad and absorb the final partial block, leaving the digest in
+	/// `state[..POSEIDON2_OUTPUT]`.
+	///
+	/// Takes `&mut self` deliberately (security review): the previous
+	/// `self`-consuming finalize chain moved the entire sponge — buffered
+	/// input and post-permutation output — by value through several stack
+	/// frames, and Rust moves are copies that leave the moved-from slot dead
+	/// but never dropped, beyond any caller's ability to wipe. Callers hash
+	/// secret material (e.g. wormhole secrets are `hash_bytes` outputs), so
+	/// every such dead copy is key-material residue. Finalizing in place
+	/// keeps the sponge in exactly one location, which [`Self::wipe`] then
+	/// clears (pinned by `tests/stack_zeroization.rs`, release builds).
+	fn finalize_state(&mut self) {
 		self.push_to_buf(Goldilocks::ONE);
 		while self.buf_len != 0 {
 			self.push_to_buf(Goldilocks::ZERO);
 		}
-		self.state
 	}
 
-	fn finalize_to_felts(self) -> [Goldilocks; POSEIDON2_OUTPUT] {
-		let state = self.finalize_state();
-		state[..POSEIDON2_OUTPUT].try_into().expect("POSEIDON2_OUTPUT <= SPONGE_WIDTH")
+	fn finalize_to_felts(&mut self) -> [Goldilocks; POSEIDON2_OUTPUT] {
+		self.finalize_state();
+		self.state[..POSEIDON2_OUTPUT]
+			.try_into()
+			.expect("POSEIDON2_OUTPUT <= SPONGE_WIDTH")
 	}
 
-	fn finalize_to_bytes(self) -> [u8; 32] {
-		serialization::digest_to_bytes(&self.finalize_to_felts())
+	fn finalize_to_bytes(&mut self) -> [u8; 32] {
+		self.finalize_state();
+		self.digest_bytes()
 	}
 
-	fn finalize_squeeze_twice(mut self) -> [u8; 64] {
-		self.push_to_buf(Goldilocks::ONE);
-		while self.buf_len != 0 {
-			self.push_to_buf(Goldilocks::ZERO);
-		}
-
-		let h1: [u8; 32] = serialization::digest_to_bytes(
-			self.state[..POSEIDON2_OUTPUT]
-				.try_into()
-				.expect("POSEIDON2_OUTPUT <= SPONGE_WIDTH"),
-		);
+	fn finalize_squeeze_twice(&mut self) -> [u8; 64] {
+		self.finalize_state();
+		let mut out = [0u8; 64];
+		out[..32].copy_from_slice(&self.digest_bytes());
 		self.poseidon2.permute_mut(&mut self.state);
-		let h2: [u8; 32] = serialization::digest_to_bytes(
-			self.state[..POSEIDON2_OUTPUT]
-				.try_into()
-				.expect("POSEIDON2_OUTPUT second squeeze <= SPONGE_WIDTH"),
-		);
-
-		[h1, h2].concat().try_into().expect("64 bytes")
+		out[32..].copy_from_slice(&self.digest_bytes());
+		out
 	}
+
+	/// Serialize the digest directly from the state (same encoding as
+	/// [`serialization::digest_to_bytes`]), without materializing an
+	/// intermediate felt array.
+	fn digest_bytes(&self) -> [u8; 32] {
+		let mut out = [0u8; 32];
+		for (chunk, felt) in out.chunks_exact_mut(8).zip(&self.state[..POSEIDON2_OUTPUT]) {
+			chunk.copy_from_slice(&felt.as_canonical_u64().to_le_bytes());
+		}
+		out
+	}
+
+	/// Overwrite the sponge (absorbed input and squeezed output) with zeros.
+	///
+	/// Called by every public hash function before returning, so the only
+	/// copy of the digest that survives the call is the returned value, and
+	/// no absorbed input block lingers in the buffer.
+	fn wipe(&mut self) {
+		wipe_felts(&mut self.state);
+		wipe_felts(&mut self.buf);
+		self.buf_len = 0;
+	}
+}
+
+/// Overwrite field elements with zeros, resistant to dead-store elimination.
+///
+/// `Goldilocks` has no `Drop`/zeroization behavior, and a plain zeroing loop
+/// over memory that is never read again is a dead store the optimizer may
+/// elide. Routing the just-written slice through [`core::hint::black_box`]
+/// makes the compiler assume the zeros are observed, so the fill must be
+/// materialized. This is best-effort by the language rules (no `unsafe`, no
+/// dependency), and the release-mode painted-stack probe in
+/// `tests/stack_zeroization.rs` pins that it actually survives codegen.
+fn wipe_felts(felts: &mut [Goldilocks]) {
+	felts.fill(Goldilocks::ZERO);
+	core::hint::black_box(felts);
 }
 
 // ============================================================================
@@ -107,39 +145,58 @@ impl Poseidon2State {
 ///
 /// This is the primary hash function. Use this when you need to chain hashes
 /// or work with field elements directly (e.g., in circuits).
+///
+/// The sponge state is wiped before returning, so no copy of the input or
+/// output survives this call's stack frame (inputs and outputs may be
+/// secrets — e.g. wormhole secret derivation hashes secret material).
 pub fn hash_to_felts(x: &[Goldilocks]) -> [Goldilocks; POSEIDON2_OUTPUT] {
 	let mut st = Poseidon2State::new();
 	st.append(x);
-	st.finalize_to_felts()
+	let out = st.finalize_to_felts();
+	st.wipe();
+	out
 }
 
 /// Hash field elements to a 32-byte digest.
 ///
 /// Converts the 4-felt hash output to bytes (8 bytes per felt).
 /// Use this when you need bytes for storage, transmission, or display.
+///
+/// The sponge state is wiped before returning; see [`hash_to_felts`].
 pub fn hash_to_bytes(x: &[Goldilocks]) -> [u8; 32] {
 	let mut st = Poseidon2State::new();
 	st.append(x);
-	st.finalize_to_bytes()
+	let out = st.finalize_to_bytes();
+	st.wipe();
+	out
 }
 
 /// Hash bytes to a 32-byte digest.
 ///
 /// Converts bytes to field elements (4 bytes per felt with terminator),
 /// then hashes the resulting field elements.
+///
+/// The sponge state is wiped before returning; see [`hash_to_felts`].
 pub fn hash_bytes(x: &[u8]) -> [u8; 32] {
 	let mut st = Poseidon2State::new();
 	st.append_bytes(x);
-	st.finalize_to_bytes()
+	let out = st.finalize_to_bytes();
+	st.wipe();
+	out
 }
 
 /// Double hash: hash(hash(input)), returning bytes.
 ///
 /// The inner hash output (4 felts) is re-hashed directly as field elements.
 /// Used for wormhole address derivation.
+///
+/// The sponge state and the intermediate digest are wiped before returning;
+/// see [`hash_to_felts`].
 pub fn hash_twice(x: &[Goldilocks]) -> [u8; 32] {
-	let inner = hash_to_felts(x);
-	hash_to_bytes(&inner)
+	let mut inner = hash_to_felts(x);
+	let out = hash_to_bytes(&inner);
+	wipe_felts(&mut inner);
+	out
 }
 
 /// Re-hash a 32-byte digest to produce a new 32-byte digest.
@@ -151,18 +208,24 @@ pub fn hash_twice(x: &[Goldilocks]) -> [u8; 32] {
 /// limb `>= P` would alias with a canonical field element and enable collisions).
 /// Digests produced by this library's hash functions are always canonical.
 pub fn rehash_to_bytes(x: &[u8; 32]) -> Result<[u8; 32], &'static str> {
-	let felts: [Goldilocks; POSEIDON2_OUTPUT] = serialization::bytes_to_digest(x)?;
-	Ok(hash_to_bytes(&felts))
+	let mut felts: [Goldilocks; POSEIDON2_OUTPUT] = serialization::bytes_to_digest(x)?;
+	let out = hash_to_bytes(&felts);
+	wipe_felts(&mut felts);
+	Ok(out)
 }
 
 /// Hash with 512-bit output by squeezing the sponge twice.
 ///
 /// Returns 64 bytes: first 32 from initial squeeze, next 32 from second squeeze.
 /// Used for mining proof-of-work.
+///
+/// The sponge state is wiped before returning; see [`hash_to_felts`].
 pub fn hash_squeeze_twice(x: &[u8]) -> [u8; 64] {
 	let mut st = Poseidon2State::new();
 	st.append_bytes(x);
-	st.finalize_squeeze_twice()
+	let out = st.finalize_squeeze_twice();
+	st.wipe();
+	out
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,15 +63,11 @@ impl Poseidon2State {
 	/// Pad and absorb the final partial block, leaving the digest in
 	/// `state[..POSEIDON2_OUTPUT]`.
 	///
-	/// Takes `&mut self` deliberately (security review): the previous
-	/// `self`-consuming finalize chain moved the entire sponge — buffered
-	/// input and post-permutation output — by value through several stack
-	/// frames, and Rust moves are copies that leave the moved-from slot dead
-	/// but never dropped, beyond any caller's ability to wipe. Callers hash
-	/// secret material (e.g. wormhole secrets are `hash_bytes` outputs), so
-	/// every such dead copy is key-material residue. Finalizing in place
-	/// keeps the sponge in exactly one location, which [`Self::wipe`] then
-	/// clears (pinned by `tests/stack_zeroization.rs`, release builds).
+	/// Takes `&mut self` rather than `self` (security review): consuming
+	/// finalizers moved the sponge by value, leaving dead stack copies of
+	/// secret input/output that no one could wipe. In-place finalize keeps
+	/// the sponge in one slot for [`Self::wipe`] to clear (pinned by
+	/// `tests/stack_zeroization.rs`).
 	fn finalize_state(&mut self) {
 		self.push_to_buf(Goldilocks::ONE);
 		while self.buf_len != 0 {
@@ -86,11 +82,8 @@ impl Poseidon2State {
 			.expect("POSEIDON2_OUTPUT <= SPONGE_WIDTH")
 	}
 
-	// The `_to_bytes` finalizers below pass `digest_to_bytes` a *borrowed*
-	// subarray of the state (`try_into` on a slice yields `&[Goldilocks; 4]`,
-	// a reference conversion with no copy) rather than an owned felt array:
-	// an owned intermediate would be one more digest copy on the stack for
-	// [`Self::wipe`] to miss.
+	// `try_into` on the state slice yields a *borrowed* `&[Goldilocks; 4]`,
+	// so no owned digest copy is created for [`Self::wipe`] to miss.
 	fn finalize_to_bytes(&mut self) -> [u8; 32] {
 		self.finalize_state();
 		serialization::digest_to_bytes(
@@ -117,11 +110,8 @@ impl Poseidon2State {
 		out
 	}
 
-	/// Overwrite the sponge (absorbed input and squeezed output) with zeros.
-	///
-	/// Called by every public hash function before returning, so the only
-	/// copy of the digest that survives the call is the returned value, and
-	/// no absorbed input block lingers in the buffer.
+	/// Zero the sponge (absorbed input and squeezed output). Every public
+	/// hash function calls this before returning.
 	fn wipe(&mut self) {
 		wipe_felts(&mut self.state);
 		wipe_felts(&mut self.buf);
@@ -129,15 +119,9 @@ impl Poseidon2State {
 	}
 }
 
-/// Overwrite field elements with zeros, resistant to dead-store elimination.
-///
-/// `Goldilocks` has no `Drop`/zeroization behavior, and a plain zeroing loop
-/// over memory that is never read again is a dead store the optimizer may
-/// elide. Routing the just-written slice through [`core::hint::black_box`]
-/// makes the compiler assume the zeros are observed, so the fill must be
-/// materialized. This is best-effort by the language rules (no `unsafe`, no
-/// dependency), and the release-mode painted-stack probe in
-/// `tests/stack_zeroization.rs` pins that it actually survives codegen.
+/// Zero field elements, resistant to dead-store elimination: `black_box`
+/// makes the compiler assume the zeros are observed, so the fill can't be
+/// elided (verified by the painted-stack probe in `tests/stack_zeroization.rs`).
 fn wipe_felts(felts: &mut [Goldilocks]) {
 	felts.fill(Goldilocks::ZERO);
 	core::hint::black_box(felts);
@@ -152,9 +136,8 @@ fn wipe_felts(felts: &mut [Goldilocks]) {
 /// This is the primary hash function. Use this when you need to chain hashes
 /// or work with field elements directly (e.g., in circuits).
 ///
-/// The sponge state is wiped before returning, so no copy of the input or
-/// output survives this call's stack frame (inputs and outputs may be
-/// secrets — e.g. wormhole secret derivation hashes secret material).
+/// The sponge state is wiped before returning, so no copy of the (possibly
+/// secret) input or output survives this call's stack frame.
 pub fn hash_to_felts(x: &[Goldilocks]) -> [Goldilocks; POSEIDON2_OUTPUT] {
 	let mut st = Poseidon2State::new();
 	st.append(x);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,47 +75,46 @@ impl Poseidon2State {
 		}
 	}
 
-	fn finalize_to_felts(&mut self) -> [Goldilocks; POSEIDON2_OUTPUT] {
-		self.finalize_state();
+	/// Borrow the digest portion of the state — a reference conversion, so no
+	/// owned digest copy is created for [`Self::wipe`] to miss.
+	fn digest(&self) -> &[Goldilocks; POSEIDON2_OUTPUT] {
 		self.state[..POSEIDON2_OUTPUT]
 			.try_into()
 			.expect("POSEIDON2_OUTPUT <= SPONGE_WIDTH")
 	}
 
-	// `try_into` on the state slice yields a *borrowed* `&[Goldilocks; 4]`,
-	// so no owned digest copy is created for [`Self::wipe`] to miss.
+	fn finalize_to_felts(&mut self) -> [Goldilocks; POSEIDON2_OUTPUT] {
+		self.finalize_state();
+		*self.digest()
+	}
+
 	fn finalize_to_bytes(&mut self) -> [u8; 32] {
 		self.finalize_state();
-		serialization::digest_to_bytes(
-			self.state[..POSEIDON2_OUTPUT]
-				.try_into()
-				.expect("POSEIDON2_OUTPUT <= SPONGE_WIDTH"),
-		)
+		serialization::digest_to_bytes(self.digest())
 	}
 
 	fn finalize_squeeze_twice(&mut self) -> [u8; 64] {
 		self.finalize_state();
 		let mut out = [0u8; 64];
-		out[..32].copy_from_slice(&serialization::digest_to_bytes(
-			self.state[..POSEIDON2_OUTPUT]
-				.try_into()
-				.expect("POSEIDON2_OUTPUT <= SPONGE_WIDTH"),
-		));
+		out[..32].copy_from_slice(&serialization::digest_to_bytes(self.digest()));
 		self.poseidon2.permute_mut(&mut self.state);
-		out[32..].copy_from_slice(&serialization::digest_to_bytes(
-			self.state[..POSEIDON2_OUTPUT]
-				.try_into()
-				.expect("POSEIDON2_OUTPUT second squeeze <= SPONGE_WIDTH"),
-		));
+		out[32..].copy_from_slice(&serialization::digest_to_bytes(self.digest()));
 		out
 	}
 
-	/// Zero the sponge (absorbed input and squeezed output). Every public
-	/// hash function calls this before returning.
+	/// Zero the sponge (absorbed input and squeezed output).
 	fn wipe(&mut self) {
 		wipe_felts(&mut self.state);
 		wipe_felts(&mut self.buf);
 		self.buf_len = 0;
+	}
+}
+
+/// Wipe the sponge when the state goes out of scope — including on unwind,
+/// so a panic mid-hash cannot skip zeroization.
+impl Drop for Poseidon2State {
+	fn drop(&mut self) {
+		self.wipe();
 	}
 }
 
@@ -136,14 +135,13 @@ fn wipe_felts(felts: &mut [Goldilocks]) {
 /// This is the primary hash function. Use this when you need to chain hashes
 /// or work with field elements directly (e.g., in circuits).
 ///
-/// The sponge state is wiped before returning, so no copy of the (possibly
-/// secret) input or output survives this call's stack frame.
+/// The sponge state is wiped when it drops at the end of this call (even on
+/// panic), so no copy of the (possibly secret) input or output survives this
+/// call's stack frame.
 pub fn hash_to_felts(x: &[Goldilocks]) -> [Goldilocks; POSEIDON2_OUTPUT] {
 	let mut st = Poseidon2State::new();
 	st.append(x);
-	let out = st.finalize_to_felts();
-	st.wipe();
-	out
+	st.finalize_to_felts()
 }
 
 /// Hash field elements to a 32-byte digest.
@@ -155,9 +153,7 @@ pub fn hash_to_felts(x: &[Goldilocks]) -> [Goldilocks; POSEIDON2_OUTPUT] {
 pub fn hash_to_bytes(x: &[Goldilocks]) -> [u8; 32] {
 	let mut st = Poseidon2State::new();
 	st.append(x);
-	let out = st.finalize_to_bytes();
-	st.wipe();
-	out
+	st.finalize_to_bytes()
 }
 
 /// Hash bytes to a 32-byte digest.
@@ -169,9 +165,7 @@ pub fn hash_to_bytes(x: &[Goldilocks]) -> [u8; 32] {
 pub fn hash_bytes(x: &[u8]) -> [u8; 32] {
 	let mut st = Poseidon2State::new();
 	st.append_bytes(x);
-	let out = st.finalize_to_bytes();
-	st.wipe();
-	out
+	st.finalize_to_bytes()
 }
 
 /// Double hash: hash(hash(input)), returning bytes.
@@ -179,8 +173,8 @@ pub fn hash_bytes(x: &[u8]) -> [u8; 32] {
 /// The inner hash output (4 felts) is re-hashed directly as field elements.
 /// Used for wormhole address derivation.
 ///
-/// The sponge state and the intermediate digest are wiped before returning;
-/// see [`hash_to_felts`].
+/// The sponge state (on drop) and the intermediate digest are wiped before
+/// returning; see [`hash_to_felts`].
 pub fn hash_twice(x: &[Goldilocks]) -> [u8; 32] {
 	let mut inner = hash_to_felts(x);
 	let out = hash_to_bytes(&inner);
@@ -208,13 +202,11 @@ pub fn rehash_to_bytes(x: &[u8; 32]) -> Result<[u8; 32], &'static str> {
 /// Returns 64 bytes: first 32 from initial squeeze, next 32 from second squeeze.
 /// Used for mining proof-of-work.
 ///
-/// The sponge state is wiped before returning; see [`hash_to_felts`].
+/// The sponge state is wiped on drop; see [`hash_to_felts`].
 pub fn hash_squeeze_twice(x: &[u8]) -> [u8; 64] {
 	let mut st = Poseidon2State::new();
 	st.append_bytes(x);
-	let out = st.finalize_squeeze_twice();
-	st.wipe();
-	out
+	st.finalize_squeeze_twice()
 }
 
 #[cfg(test)]

--- a/tests/stack_zeroization.rs
+++ b/tests/stack_zeroization.rs
@@ -1,19 +1,12 @@
-//! Regression test (security review): hash outputs must not survive in dead
-//! stack memory after the hash call returns.
-//!
-//! Consumers hash secret material with this crate — e.g. Quantus wormhole
-//! secrets are literally `hash_bytes(entropy)`, so the *output* of the hash
-//! is a secret. The finalize path previously moved the whole sponge state by
-//! value through three `self`-consuming methods and returned the state array
-//! by value; every one of those moves left a dead, never-dropped stack copy
-//! of the output (and of buffered input) that no caller could ever wipe. The
-//! fixed pipeline finalizes through `&mut self`, serializes the digest
-//! directly from the state, and wipes the sponge before returning.
+//! Regression test (security review): hash inputs and outputs must not
+//! survive in dead stack memory after the hash call returns — consumers hash
+//! secrets (e.g. Quantus wormhole secrets are `hash_bytes` outputs). The old
+//! `self`-consuming finalize chain moved the sponge by value, leaving dead
+//! unwipeable copies; the fixed pipeline finalizes in place and wipes.
 //!
 //! Technique: run the hash on a freshly painted stack buffer (`psm`), then
-//! scan the buffer for the known output pattern. The assertion is about
-//! codegen (which temporaries get wiped), so it is only compiled for
-//! optimized builds (`cargo test --release`).
+//! scan the buffer for the known pattern. The assertion is about codegen, so
+//! it is only compiled for optimized builds (`cargo test --release`).
 #![cfg(not(debug_assertions))]
 
 use std::alloc::{alloc, dealloc, Layout};
@@ -70,9 +63,8 @@ fn hash_bytes_output_never_survives_on_stack() {
 	let leaked = probe_stack_for(&output, || {
 		let mut out = hash_bytes(&INPUT);
 		core::hint::black_box(&out);
-		// `out` is the caller-owned copy; a secret-holding caller wipes it
-		// (the wormhole code does). Wipe it here so the scan only sees
-		// copies the library left behind, which no caller could reach.
+		// Wipe the caller-owned copy (as a secret-holding caller would) so
+		// the scan only sees copies the library left behind.
 		out.fill(0);
 		core::hint::black_box(&mut out);
 	});
@@ -99,15 +91,12 @@ fn hash_twice_input_never_survives_on_stack() {
 	}
 
 	let leaked = probe_stack_for(&input_pattern, || {
-		// Bound as `mut` from the start: a later `let mut felts = felts;`
-		// rebinding would be a move that leaves the original slot as dead
-		// unwipeable residue — exactly the bug class this probe hunts.
+		// `mut` from the start: rebinding later would move `felts`, leaving
+		// the original slot as dead residue — the bug class this probe hunts.
 		let mut felts = bytes_to_digest_lossy(&INPUT);
 		let out = hash_twice(&felts);
 		core::hint::black_box(&out);
-		// `felts` is the caller's own copy; a real secret-holding caller
-		// wipes it (the wormhole code does). Simulate that here so the scan
-		// only sees sponge-internal copies.
+		// Wipe the caller-owned copy so the scan only sees sponge-internal ones.
 		felts.fill(qp_poseidon_core::Goldilocks::ZERO);
 		core::hint::black_box(&mut felts);
 	});

--- a/tests/stack_zeroization.rs
+++ b/tests/stack_zeroization.rs
@@ -1,0 +1,120 @@
+//! Regression test (security review): hash outputs must not survive in dead
+//! stack memory after the hash call returns.
+//!
+//! Consumers hash secret material with this crate — e.g. Quantus wormhole
+//! secrets are literally `hash_bytes(entropy)`, so the *output* of the hash
+//! is a secret. The finalize path previously moved the whole sponge state by
+//! value through three `self`-consuming methods and returned the state array
+//! by value; every one of those moves left a dead, never-dropped stack copy
+//! of the output (and of buffered input) that no caller could ever wipe. The
+//! fixed pipeline finalizes through `&mut self`, serializes the digest
+//! directly from the state, and wipes the sponge before returning.
+//!
+//! Technique: run the hash on a freshly painted stack buffer (`psm`), then
+//! scan the buffer for the known output pattern. The assertion is about
+//! codegen (which temporaries get wiped), so it is only compiled for
+//! optimized builds (`cargo test --release`).
+#![cfg(not(debug_assertions))]
+
+use std::alloc::{alloc, dealloc, Layout};
+
+use qp_poseidon_core::{hash_bytes, hash_twice, serialization::bytes_to_digest_lossy};
+
+const PAINT: u8 = 0xAA;
+// Poseidon2 hashing is shallow; 1 MiB is ample.
+const STACK_BYTES: usize = 1024 * 1024;
+const ALIGN: usize = 4096;
+
+/// Run `f` on a freshly painted stack buffer, then scan the buffer for
+/// `pattern` and return whether it was found.
+fn probe_stack_for<F: FnOnce()>(pattern: &[u8], f: F) -> bool {
+	let layout = Layout::from_size_align(STACK_BYTES, ALIGN).unwrap();
+	unsafe {
+		let base = alloc(layout);
+		assert!(!base.is_null(), "probe stack allocation failed");
+		std::ptr::write_bytes(base, PAINT, STACK_BYTES);
+
+		psm::on_stack(base, STACK_BYTES, f);
+
+		let region = std::slice::from_raw_parts(base, STACK_BYTES);
+		let offsets: Vec<usize> = region
+			.windows(pattern.len())
+			.enumerate()
+			.filter(|(_, w)| w == &pattern)
+			.map(|(i, _)| i)
+			.collect();
+		eprintln!("probe: {} match(es) at offsets {:?}", offsets.len(), offsets);
+		let found = !offsets.is_empty();
+		dealloc(base, layout);
+		found
+	}
+}
+
+/// Distinctive ASCII input so matches can only come from verbatim copies.
+const INPUT: [u8; 32] = *b"poseidon-probe-input-0123456789A";
+
+#[test]
+fn hash_bytes_output_never_survives_on_stack() {
+	// Reference output, computed outside the probed region.
+	let output = hash_bytes(&INPUT);
+
+	// Sanity: the technique detects an unwiped copy.
+	assert!(
+		probe_stack_for(&output, || {
+			let leaked: [u8; 32] = output;
+			core::hint::black_box(&leaked);
+		}),
+		"probe self-check: a deliberately leaked output copy was not detected"
+	);
+
+	let leaked = probe_stack_for(&output, || {
+		let mut out = hash_bytes(&INPUT);
+		core::hint::black_box(&out);
+		// `out` is the caller-owned copy; a secret-holding caller wipes it
+		// (the wormhole code does). Wipe it here so the scan only sees
+		// copies the library left behind, which no caller could reach.
+		out.fill(0);
+		core::hint::black_box(&mut out);
+	});
+	assert!(
+		!leaked,
+		"hash_bytes left a copy of its output in dead stack memory; callers \
+		 hashing secrets (e.g. wormhole secret derivation) cannot wipe it"
+	);
+}
+
+#[test]
+fn hash_twice_input_never_survives_on_stack() {
+	// hash_twice is used for wormhole address derivation, where the *input*
+	// felts encode the secret (8 bytes/felt, byte-identical to the secret for
+	// canonical limbs). The input slice itself belongs to the caller; this
+	// probes for sponge-internal copies of it.
+	let felts = bytes_to_digest_lossy(&INPUT);
+	let output = hash_twice(&felts);
+
+	// The input pattern as it appears in felt form (LE u64 limbs).
+	let mut input_pattern = [0u8; 32];
+	for (chunk, felt) in input_pattern.chunks_exact_mut(8).zip(felts.iter()) {
+		chunk.copy_from_slice(&felt.as_canonical_u64().to_le_bytes());
+	}
+
+	let leaked = probe_stack_for(&input_pattern, || {
+		// Bound as `mut` from the start: a later `let mut felts = felts;`
+		// rebinding would be a move that leaves the original slot as dead
+		// unwipeable residue — exactly the bug class this probe hunts.
+		let mut felts = bytes_to_digest_lossy(&INPUT);
+		let out = hash_twice(&felts);
+		core::hint::black_box(&out);
+		// `felts` is the caller's own copy; a real secret-holding caller
+		// wipes it (the wormhole code does). Simulate that here so the scan
+		// only sees sponge-internal copies.
+		felts.fill(qp_poseidon_core::Goldilocks::ZERO);
+		core::hint::black_box(&mut felts);
+	});
+	assert!(
+		!leaked,
+		"hash_twice left a sponge-internal copy of its input in dead stack \
+		 memory; wormhole secrets are absorbed through this path"
+	);
+	core::hint::black_box(&output);
+}


### PR DESCRIPTION
# Wipe the sponge state after hashing so secrets don't linger on the stack

## Problem

Consumers of this crate hash secret material: a Quantus wormhole secret is
literally the output of `hash_bytes`, and the felt-encoded secret is the input
to the address-derivation hashes. A painted-stack probe in
`qp-rusty-crystals` (release-mode `wormhole_stack_zeroization` test) found
verbatim copies of the wormhole secret in dead stack memory after every
zeroizing wrapper on the caller's side had done its job. Bisection traced the
residue into this crate.

**Root cause:** the finalize pipeline was a chain of `self`-consuming methods —
`finalize_to_bytes(self)` → `finalize_to_felts(self)` → `finalize_state(mut
self)`. Each call moves the entire `Poseidon2State` (sponge state, buffered
input, permutation) by value into the callee's frame. Rust moves are copies:
every moved-from slot stays behind as a dead, never-dropped copy of the
sponge — which contains the squeezed digest and any buffered input block —
that no caller can ever reach or wipe. `finalize_squeeze_twice` additionally
built its output with `[h1, h2].concat()`, leaking the digest into a freed
heap block.

## Fix

- `finalize_state` / `finalize_to_felts` / `finalize_to_bytes` /
  `finalize_squeeze_twice` now take `&mut self`, so the sponge lives in
  exactly one stack slot for the whole hash computation. The byte finalizers
  pass `digest_to_bytes` a *borrowed* subarray of the state (`try_into` on
  the slice is a reference conversion, no copy) instead of an owned
  intermediate felt array, and the double squeeze writes into a fixed
  `[u8; 64]` instead of a heap `Vec`.
- Every public hash function (`hash_to_felts`, `hash_to_bytes`, `hash_bytes`,
  `hash_twice`, `rehash_to_bytes`, `hash_squeeze_twice`) wipes the sponge —
  and any intermediate digest-felt buffer — before returning, so the only
  surviving copy of the digest is the returned value.
- The wipe is safe code with no new runtime dependency:
  `fill(Goldilocks::ZERO)` routed through `core::hint::black_box`, which
  forces the compiler to materialize the zeroing stores instead of eliding
  them as dead. The regression test below pins that this survives codegen.

## No behavior change

Hash outputs are bit-identical: the existing known-answer vectors
(`test_known_value_hashes`, `test_hash_twice_vectors`,
`test_rehash_to_bytes_vectors`, `test_hash_squeeze_twice`) pass unchanged.
The public API is unchanged; only private methods switched from `self` to
`&mut self`. The wipe cost (20 field-element stores per hash) is negligible
next to a Poseidon2 permutation.

## Regression test

New `tests/stack_zeroization.rs` (release-mode only, `psm` dev-dependency):
runs a hash on a freshly painted stack buffer, then scans the buffer for the
known digest / input pattern.

- `hash_bytes_output_never_survives_on_stack` — red before this change
  (2 residue copies), green after.
- `hash_twice_input_never_survives_on_stack` — probes for sponge-internal
  copies of the *input* felts (the wormhole secret enters through this
  path) — red before (2 copies), green after.

Both tests include a self-check that the probe technique detects a
deliberately leaked copy.

## Downstream

With `qp-rusty-crystals` patched to this branch, its
`wormhole_stack_zeroization` probe goes fully green (zero matches). Once this
ships (as `=3.0.3`), the downstream pin gets bumped and the temporary
`[patch.crates-io]` entry removed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches secret-bearing hash paths (wormhole secrets); the fix is security-critical even though outputs stay bit-identical and the public API is unchanged.
> 
> **Overview**
> Fixes **dead stack copies** of sponge state (digest + buffered secret input) left behind by the old `self`-consuming finalize chain. Finalization now runs **in place** via `&mut self`, byte digests are built from **borrowed** state slices (no extra felt array), and `finalize_squeeze_twice` writes into a **stack `[u8; 64]`** instead of a heap `Vec`.
> 
> Adds **`wipe` / `wipe_felts`** (`fill` + `core::hint::black_box`) and calls them from every public hash path (`hash_to_felts`, `hash_to_bytes`, `hash_bytes`, `hash_twice`, `rehash_to_bytes`, `hash_squeeze_twice`) so only the returned digest survives. **Public API and hash outputs are unchanged** (KATs unchanged).
> 
> New **release-only** `tests/stack_zeroization.rs` (dev-dep `psm`) painted-stack probes for `hash_bytes` output and `hash_twice` sponge-internal input residue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 847033b7a2ca1ce6e63ca7195e3c7627b26b8012. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->