### PR TITLE
ci: Automate version bump to v3.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "qp-poseidon-core"
-version = "3.0.2"
+version = "3.1.0"
 dependencies = [
  "criterion",
  "dudect-bencher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qp-poseidon-core"
-version = "3.0.2"
+version = "3.1.0"
 authors = ["Quantus Network Developers <hello@quantus.com>"]
 homepage = "https://quantus.com"
 repository = "https://github.com/Quantus-Network/qp-poseidon"


### PR DESCRIPTION
Automated version bump for release v3.1.0.

https://github.com/Quantus-Network/qp-poseidon/actions/runs/30795612973

Triggered by workflow run: minor

Type: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version metadata only; no runtime or cryptographic logic changes.
> 
> **Overview**
> **Release v3.1.0** — automated minor version bump only.
> 
> Updates `qp-poseidon-core` from **3.0.2** to **3.1.0** in `Cargo.toml` and the matching `[[package]]` entry in `Cargo.lock`. No library source, API, or dependency changes beyond the version string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cfee408d8d88449988df19ecc72ec46fb460b26. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->