### PR TITLE
Const-constructible Poseidon2 + shared static instance + mining golden vectors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,16 +11,20 @@ pub use poseidon2::{Poseidon2, POSEIDON2_OUTPUT, SPONGE_CAPACITY, SPONGE_RATE, S
 
 // Internal state for Poseidon2 hashing
 struct Poseidon2State {
-	poseidon2: Poseidon2,
+	poseidon2: &'static Poseidon2,
 	state: [Goldilocks; SPONGE_WIDTH],
 	buf: [Goldilocks; SPONGE_RATE],
 	buf_len: usize,
 }
 
+/// Shared instance: the permutation constants are fixed, so constructing a
+/// `Poseidon2` per hash would just re-copy ~1KB of constant data per call.
+static POSEIDON2: Poseidon2 = Poseidon2::new();
+
 impl Poseidon2State {
 	fn new() -> Self {
 		Self {
-			poseidon2: Poseidon2::new(),
+			poseidon2: &POSEIDON2,
 			state: [Goldilocks::ZERO; SPONGE_WIDTH],
 			buf: [Goldilocks::ZERO; SPONGE_RATE],
 			buf_len: 0,

--- a/src/poseidon2.rs
+++ b/src/poseidon2.rs
@@ -219,17 +219,49 @@ impl Default for Poseidon2 {
 
 impl Poseidon2 {
 	/// Create a new Poseidon2 instance with precomputed constants.
-	pub fn new() -> Self {
-		let internal_constants = core::array::from_fn(|i| Goldilocks::new(INTERNAL_CONSTANTS[i]));
-		let matrix_diag = core::array::from_fn(|i| Goldilocks::new(MATRIX_DIAG[i]));
+	///
+	/// `const` so callers can hoist the instance into a `static` and avoid
+	/// re-initializing the constants on every hash.
+	pub const fn new() -> Self {
+		let mut internal_constants = [Goldilocks::ZERO; INTERNAL_ROUNDS];
+		let mut i = 0;
+		while i < INTERNAL_ROUNDS {
+			internal_constants[i] = Goldilocks::new(INTERNAL_CONSTANTS[i]);
+			i += 1;
+		}
 
-		let initial_external_constants = core::array::from_fn(|r| {
-			core::array::from_fn(|i| Goldilocks::new(INITIAL_EXTERNAL_CONSTANTS[r][i]))
-		});
+		let mut matrix_diag = [Goldilocks::ZERO; SPONGE_WIDTH];
+		let mut i = 0;
+		while i < SPONGE_WIDTH {
+			matrix_diag[i] = Goldilocks::new(MATRIX_DIAG[i]);
+			i += 1;
+		}
 
-		let terminal_external_constants = core::array::from_fn(|r| {
-			core::array::from_fn(|i| Goldilocks::new(TERMINAL_EXTERNAL_CONSTANTS[r][i]))
-		});
+		let mut initial_external_constants =
+			[[Goldilocks::ZERO; SPONGE_WIDTH]; HALF_EXTERNAL_ROUNDS];
+		let mut r = 0;
+		while r < HALF_EXTERNAL_ROUNDS {
+			let mut i = 0;
+			while i < SPONGE_WIDTH {
+				initial_external_constants[r][i] =
+					Goldilocks::new(INITIAL_EXTERNAL_CONSTANTS[r][i]);
+				i += 1;
+			}
+			r += 1;
+		}
+
+		let mut terminal_external_constants =
+			[[Goldilocks::ZERO; SPONGE_WIDTH]; HALF_EXTERNAL_ROUNDS];
+		let mut r = 0;
+		while r < HALF_EXTERNAL_ROUNDS {
+			let mut i = 0;
+			while i < SPONGE_WIDTH {
+				terminal_external_constants[r][i] =
+					Goldilocks::new(TERMINAL_EXTERNAL_CONSTANTS[r][i]);
+				i += 1;
+			}
+			r += 1;
+		}
 
 		Self {
 			internal_constants,

--- a/tests/golden_vectors.rs
+++ b/tests/golden_vectors.rs
@@ -1,0 +1,61 @@
+//! Golden value tests for the Poseidon2 hash (mining path).
+//!
+//! Captured from qp-poseidon-core v3.1.0 (commit f885ad5, pre-optimization).
+//! Any performance work must reproduce these byte-for-byte.
+//!
+//! Input layout mirrors CPU mining: 32-byte header || 64-byte big-endian U512
+//! nonce = 96 bytes, hashed with `hash_squeeze_twice` (as `get_nonce_hash` does).
+
+use qp_poseidon_core::hash_squeeze_twice;
+
+fn mining_input(header_seed: u8, nonce: u64) -> [u8; 96] {
+	let mut input = [0u8; 96];
+	for b in input[..32].iter_mut() {
+		*b = header_seed;
+	}
+	// U512 big-endian nonce occupies the last 64 bytes; value sits in the low 8.
+	input[88..96].copy_from_slice(&nonce.to_be_bytes());
+	input
+}
+
+const GOLDEN: &[(&str, u8, u64, &str)] = &[
+	(
+		"zero header, nonce 0",
+		0x00,
+		0,
+		"8e64e3d8e0f38f882e8501f9e525df0a95d2e91e9cfc32c9248d756fb07780e2f8fdca2c5a54441e6fcd8d774a5f6aae72f36d1c76bc19f691a0d4f6c607e8cc",
+	),
+	(
+		"zero header, nonce 1",
+		0x00,
+		1,
+		"9a18eabb9d910135a553a511209963dfafd2dc62989e2e013c18d626fa17c66fd3899fc3fe2bcc88be8ce416a4bd15e9f157cc5b251112f93938b38617548f6c",
+	),
+	(
+		"0x01 header, nonce 123",
+		0x01,
+		123,
+		"0c580156318afca56700b7a2cafa4f44277a6c7ea668717984ed26b8169d277521951b73329d898590e953c35d036726becb74bc29d765112ec99b14d0dc5189",
+	),
+	(
+		"0xff header, nonce u64::MAX",
+		0xff,
+		u64::MAX,
+		"822f70999ee517f610b51bbb79ba88bfbb19cb77b316df25d8aeb4c2682673555e9fc6a588ee96dcce4ff0d2b8d97f4aa89d0f46c97f9027b386d42b14be5100",
+	),
+	(
+		"0x2a header, nonce 0xdeadbeef",
+		0x2a,
+		0xdeadbeef,
+		"f974a312ffd7b21ba3e71c499cf178e39d19d178b4483da321da23c48c02e7c874561d93d6e590656905c21a0142a512fe1ebbf69babc904fe1c359f72e5420c",
+	),
+];
+
+#[test]
+fn test_mining_golden_vectors() {
+	for (name, seed, nonce, expected_hex) in GOLDEN {
+		let input = mining_input(*seed, *nonce);
+		let out = hash_squeeze_twice(&input);
+		assert_eq!(hex::encode(out), *expected_hex, "golden mismatch for {name}");
+	}
+}


### PR DESCRIPTION
## Overview
Prep work for CPU-mining performance: make the permutation constants usable from `const`/`static` contexts, and pin the mining hash path to golden values so optimization work has a fixed correctness anchor.

## What changed
- `src/poseidon2.rs`: `Poseidon2::new()` is now a `const fn` (explicit `while` loops instead of `array::from_fn`).
- `src/lib.rs`: hash entry points (`hash_bytes`, `hash_squeeze_twice`, `hash_to_felts`, …) share a single `static POSEIDON2` instead of constructing a fresh `Poseidon2` (~1KB of constants) per call.
- `tests/golden_vectors.rs` (new): golden values for mining-shape 96-byte inputs (32-byte header `||` 64-byte big-endian nonce) through `hash_squeeze_twice`, captured from v3.1.0 (f885ad5).

## Validation
- `cargo test --release`: 78 tests pass, including the new goldens and all existing KATs.
- `cargo clippy --all-targets --release -- -D warnings`: clean.
- Criterion against a saved pre-change baseline (`hash_squeeze_twice`, `initialization` groups): no significant change — LLVM was already eliminating the per-call constant construction; this commit makes that explicit and lets downstream crates hold a `static Poseidon2` themselves.

## Risks and mitigations
- No algorithm changes: goldens + KATs + p3-derived permutation vectors all pass byte-for-byte.
- API is additive-only (`new()` signature unchanged, now const).

## Follow-ups
- quantus-miner CPU engine switches to a midstate-based hashing path (separate PR) that relies on `Poseidon2` being cheap to share.